### PR TITLE
Remove extra out argument sent to Parcel and reduce logging in output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ msg.pb.d.ts: msg.pb.js node_modules
 
 dist/main.js: $(TS_FILES) node_modules
 	./node_modules/.bin/tsc --noEmit # Only for type checking.
-	./node_modules/.bin/parcel build --log-level 1 --no-minify main.ts
+	./node_modules/.bin/parcel build --out-dir=dist/ --log-level=1 --no-minify main.ts
 
 node_modules:
 	yarn

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ msg.pb.d.ts: msg.pb.js node_modules
 
 dist/main.js: $(TS_FILES) node_modules
 	./node_modules/.bin/tsc --noEmit # Only for type checking.
-	./node_modules/.bin/parcel build --out-dir=dist/ --no-minify main.ts
+	./node_modules/.bin/parcel build --log-level 1 --no-minify main.ts
 
 node_modules:
 	yarn


### PR DESCRIPTION
This is printing too much!

<img width="970" alt="screen shot 2018-05-30 at 11 18 11 am" src="https://user-images.githubusercontent.com/543633/40739692-b25f7516-63fb-11e8-9e94-c02ad87eac8b.png">