### PR TITLE
Use docker for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# improve docker build performance excluding some directories
+
+.cache
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,36 @@
-language: c++
-cache:
-  ccache: true
-  directories:
-   - .cache/
-   - node_modules/
-   - $V8WORKER2_OUT_PATH
+dist: trusty
+
+sudo: required
+
+services:
+- docker
+
+# Configure docker hub secure variables running:
+# travis encrypt DOCKER_USERNAME=XXXXXX --repo ry/deno --add env.global --no-interactive
+# travis encrypt DOCKER_PASSWORD=XXXXXX --repo ry/deno --add env.global --no-interactive
 env:
   global:
-    - V8WORKER2_OUT_PATH=$HOME/v8worker2_out
-    - PROTOBUF_ROOT=$HOME/protobuf
-before_install: |
-  # protobuf
-  export PATH=$PROTOBUF_ROOT/bin:$PATH
-  if ! [ -x $PROTOBUF_ROOT/bin/protoc ]; then
-    rm -rf $PROTOBUF_ROOT
-    mkdir -p $PROTOBUF_ROOT
-    pushd $PROTOBUF_ROOT
-    wget https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip
-    unzip protoc-3.1.0-linux-x86_64.zip
-    popd
-  fi
-install:
- - mkdir -p $GOPATH/src/github.com/ry
- - ln -s `pwd` $GOPATH/src/github.com/ry/deno
- - env
- - go get -d github.com/ry/v8worker2
- - $GOPATH/src/github.com/ry/v8worker2/build.py --use_ccache --out_path $V8WORKER2_OUT_PATH
- - go get -u github.com/golang/protobuf/proto
- - go get -u github.com/spf13/afero
- - go get -u github.com/golang/protobuf/protoc-gen-go
- - go get -u github.com/jteeuwen/go-bindata/...
- - yarn
-script:
- - make lint
- - make test
+  - DOCKER_REGISTRY: aledbf/deno
+  - DOCKER_TAG: dev-0.1
+  - secure: W2Cr+EWC0czWox5caMp8Uqi7rlRtZgEanQXSCc3VDfNArdVAQ1kl8UI3CIkgq6YNOr81oR6ZKzStN4rlxwgItQwmlgdJWvPQr5mKIfpskG8uMd30FmF8CJ6DAiNknka6GTbY2qgzGk6yqh1oO31LZUTuxyu09bEPcida6axXcTpDyCTL5wt/ySjyFSAdZxYZJWiFuQBYetgTIGsz4+eq1AYdoDi4JDYrvWSDUNKrnphsRwvrmhZTXau2xDOsAikiBgjKss12esZJVR5cUxbOix3MXayQKlLTj1SRA3XsCnPqBLmVSry6ukO+D/8148Mn616vWfJro82bUcleVu1Yt7fUuM+io/iGNr1ak+gIck/4jm6TchkSdhZL4dq36KHile3JnkCgviAK7Ac7THlO7BYG6zXXTX6MEFg1BlBAxJH9bdkusEaLBE02sAqoIw/CalkbXJFrBecoTRQfcitEy8cKw5BzBtC80BHJ7WZmhPAqKWjGxSQNMpBuS1tRkgl6SHRhU5YCkRZwCDoaPl3qS91n3zEt/zkm6/4FDUnYXLTYb06Mgi9qo6bY6wr9sOaNT6SxolkKiBMkJBCX1nziM82JACRsI6lkvmheP6qrHnpEox8jNu9JfoJetU5+nfljjcjSTQjvvVLT11lENS1MwJMFpTMpfENTDDspvkQ++Hk=
+  - secure: oOCUJsliZy8k5NDME5shlGUOvdC0rkOlvuWuBJCJe5EwxLB12R6u6zxOh7eqkrIEIevDPjzXEpHc47aE1FnSJur1UL6qHiw23ImgSBAlu2LckTG+qh8JZtDx+kDEuCzaTj42hOu7PbIpvZXC+Rsm8pOgSLpWaOpJkmx22KqaC5q0MIKAn21T4NAn7nFwis80D2xlA2TyBUA/BuZTB6cf3LU0OqyMhW/B1X1AAigMJQQ4KNloQ8MdnohCTEsLchZKjBMXi5arLvieS2YPoY6YTess9c4CoW0MylT3TWLh0vcvELnwxA9QjkiRYaVzwMT/NdEWVRkqxk31s9T4wofnnLQQpWsMQaN/0EfekP1O3GtrDG15WO6buXZjOwTOZDf57HKXZc5Gs9CxLR5NZP/7OejTb//7weaPzegmxTG6ExoouVcbfJDgkDeWUgWWSE5HEH6d+HEsTvxLSGu5PgLg38kJuEMhI/c7nlgroE7gkq4pB43yjdbYRtf5xjLBJG/WqQ6dB+spwLFKesZ+LxTcdb/wPWjH46HgAYm6kean/uaNXRb6r/yqUjpy75o5HPeygaG6JDcGeW0kLdPOpWXjE21U+EDamX+OsimIR5KMQOTWyTtopqJvxR7dSYV9pS/KEij9KOp+xr8rWmJf2ww9hWnI3qzoHUYSSIo8MUSWjc4=
+
+jobs:
+  include:
+
+  - stage: Build docker image
+    # secure variables are not available in PRs
+    if: (NOT type IN (pull_request)) AND (branch = master)
+    script:
+    - |
+      echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin;
+      docker pull $DOCKER_REGISTRY:$DOCKER_TAG || true;
+      make build-image && make push-image
+
+  - stage: Lint
+    script:
+    - ./run-container.sh lint
+
+  - stage: Test
+    script:
+    - ./run-container.sh test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    g++ \
+    gcc \
+    libc6-dev \
+    make \
+    pkg-config \
+    curl \
+    ca-certificates \
+    gnupg \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    unzip \
+    bsdtar \
+    ccache \
+    build-essential \
+    python \
+    git \
+    libperl-dev \
+    libgtk2.0-dev \
+    golang golang-src \
+    clang clang-format-5.0 \
+  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+  && apt-get update \
+  && apt-get install -y \
+    yarn \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV HOME               /
+ENV V8WORKER2_OUT_PATH /v8worker2_out
+ENV PROTOBUF_ROOT      /protobuf
+ENV GOPATH             /go
+
+ENV PATH               $PROTOBUF_ROOT/bin:${GOPATH}/bin:/usr/lib/llvm-5.0/bin:${PATH}
+
+RUN mkdir -p $PROTOBUF_ROOT \
+  && cd $PROTOBUF_ROOT \
+  && curl -sSL https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip | bsdtar -xvf- \
+  && chmod +x $PROTOBUF_ROOT/bin/protoc
+
+RUN  go get -u github.com/golang/protobuf/proto \
+  && go get -u github.com/golang/protobuf/protoc-gen-go \
+  && go get -u github.com/spf13/afero \
+  && go get -u github.com/jteeuwen/go-bindata/...
+
+RUN go get -u github.com/ry/v8worker2 || true \
+  && ccache -s \
+  && cd $GOPATH/src/github.com/ry/v8worker2 \
+  && ./build.py --use_ccache --out_path $V8WORKER2_OUT_PATH \
+  && rm -R /.vpython-root /.ccache \
+  && cd ${GOPATH}/src \
+  && for file in `find . -name .git`;do rm -rf $file;done
+
+# change permissions to allow access to any user
+RUN chmod -R a+rX /v8worker2_out
+
+ENV PKG_CONFIG_PATH $GOPATH/src/github.com/ry/v8worker2
+
+WORKDIR $GOPATH/src/github.com/ry/deno
+
+ENV YARN_WRAP_OUTPUT true
+
+CMD ["make"]

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ clean:
 distclean: clean
 	-rm -rf node_modules/
 
-lint: node_modules
+lint: node_modules deno
 	yarn lint
 	go vet
 
@@ -78,4 +78,15 @@ fmt: node_modules
 test: deno
 	go test -v
 
-.PHONY: test lint clean distclean
+# Use the dev-0.0 tag for local testing
+DOCKER_TAG ?= dev-0.1
+DOCKER_REGISTRY ?= ry/deno
+DOCKER_IMAGE ?= ${DOCKER_REGISTRY}:${DOCKER_TAG}
+
+build-image:
+	docker build -t ${DOCKER_IMAGE} .
+
+push-image:
+	docker push ${DOCKER_IMAGE}
+
+.PHONY: test lint clean distclean build-image push-image

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+USER=$(id -u)
+GROUP=$(id -g)
+
+# Use the dev-0.0 tag for local testing
+DOCKER_TAG=${DOCKER_TAG:=dev-0.1}
+DOCKER_REGISTRY=${DOCKER_REGISTRY:=ry/deno}
+
+DOCKER_IMAGE=${DOCKER_REGISTRY}:${DOCKER_TAG}
+
+docker run --rm -it \
+  -u ${USER}:${GROUP} \
+  -v ${DIR}:/go/src/github.com/ry/deno \
+  -e HOME=/go/src/github.com/ry/deno \
+  ${DOCKER_IMAGE} /bin/bash -c "make $1"


### PR DESCRIPTION
```bash
$ DOCKER_DEV_IMAGE=aledbf/deno:dev-image-0.1 make docker-dev
```
This is the output of the build https://gist.github.com/aledbf/f39189a7e7ea3beff7aee676d85e5c51

After this running `make run <makefile task>` we can run any task inside a container:

```bash
$ make run deno
yarn
yarn install v1.7.0
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.3: The platform "linux" is incompatible with this module.
info "fsevents@1.2.3" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 21.97s.
./node_modules/.bin/pbjs -t static-module -w commonjs -o msg.pb.js msg.proto
./node_modules/.bin/pbts -o msg.pb.d.ts msg.pb.js
./node_modules/.bin/tsc --noEmit # Only for type checking.
./node_modules/.bin/parcel build --out-dir=dist/ --log-level=1 --no-minify main.ts
cp node_modules/typescript/lib/*d.ts dist/
cp deno.d.ts dist/
go-bindata -pkg deno -o assets.go dist/
go build -o deno ./cmd
make: 'deno' is up to date.
```

```bash
$ make run test
go test -v
=== RUN   TestLoadOutputCodeCache
--- PASS: TestLoadOutputCodeCache (0.00s)
=== RUN   TestIntegrationFiles
=== RUN   TestIntegrationFiles/001_hello.js.out
=== RUN   TestIntegrationFiles/002_hello.ts.out
=== RUN   TestIntegrationFiles/003_relative_import.ts.out
=== RUN   TestIntegrationFiles/004_set_timeout.ts.out
=== RUN   TestIntegrationFiles/005_more_imports.ts.out
=== RUN   TestIntegrationFiles/006_url_imports.ts.out
=== RUN   TestIntegrationFiles/009_pub_sub.ts.out
=== RUN   TestIntegrationFiles/010_set_interval.ts.out
=== RUN   TestIntegrationFiles/012_async.ts.out
=== RUN   TestIntegrationFiles/async_error.ts.out
=== RUN   TestIntegrationFiles/error.ts.out
=== RUN   TestIntegrationFiles/import_typescript.ts.out
--- FAIL: TestIntegrationFiles (15.70s)
    --- PASS: TestIntegrationFiles/001_hello.js.out (1.06s)
    --- PASS: TestIntegrationFiles/002_hello.ts.out (1.05s)
    --- PASS: TestIntegrationFiles/003_relative_import.ts.out (1.13s)
    --- PASS: TestIntegrationFiles/004_set_timeout.ts.out (1.06s)
    --- PASS: TestIntegrationFiles/005_more_imports.ts.out (1.26s)
    --- PASS: TestIntegrationFiles/006_url_imports.ts.out (1.12s)
    --- FAIL: TestIntegrationFiles/009_pub_sub.ts.out (2.03s)
    	integration_test.go:61: Expected success exit status 1
    --- PASS: TestIntegrationFiles/010_set_interval.ts.out (1.60s)
    --- PASS: TestIntegrationFiles/012_async.ts.out (1.21s)
    --- PASS: TestIntegrationFiles/async_error.ts.out (1.08s)
    --- PASS: TestIntegrationFiles/error.ts.out (2.00s)
    --- PASS: TestIntegrationFiles/import_typescript.ts.out (1.11s)
=== RUN   TestIntegrationUrlArgs
good cacheFn /tmp/TestIntegration387570343/src/localhost:4545/testdata/001_hello.js
bad cacheFn /tmp/TestIntegration271357914/src/localhost:4546/testdata/001_hello.js
--- PASS: TestIntegrationUrlArgs (2.41s)
=== RUN   TestTestsTs
1/4 +0 -0: tests_test
2/4 +1 -0: tests_fetch
3/4 +2 -0: tests_readFileSync
deno_1.readFileSync is not a function TypeError: deno_1.readFileSync is not a function
    at tests_readFileSync (/go/src/github.com/ry/deno/tests.ts:13:27)
    at Object.runTests [as cb] (/go/src/github.com/ry/deno/testing/testing.ts:62:23)
--- FAIL: TestTestsTs (0.60s)
	integration_test.go:146: exit status 1
=== RUN   TestResolveModule1
--- PASS: TestResolveModule1 (0.00s)
=== RUN   TestResolveModule2
--- PASS: TestResolveModule2 (0.00s)
=== RUN   TestResolveModule3
--- PASS: TestResolveModule3 (0.00s)
=== RUN   TestResolveModule4
--- PASS: TestResolveModule4 (0.00s)
=== RUN   TestResolveModuleExtensionsAintSpecial
--- PASS: TestResolveModuleExtensionsAintSpecial (0.00s)
=== RUN   TestPatternMatch
--- PASS: TestPatternMatch (0.00s)
=== RUN   TestPatternMatchStackTrace
--- PASS: TestPatternMatchStackTrace (0.00s)
FAIL
exit status 1
FAIL	github.com/ry/deno	18.705s
Makefile:79: recipe for target 'test' failed
make: *** [test] Error 1
Makefile:95: recipe for target 'run' failed
make: *** [run] Error 2
```

```bash
$ ldd deno
	linux-vdso.so.1 (0x00007ffcca0f9000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fb3de490000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fb3de102000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fb3ddd64000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fb3ddb4c000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fb3dd75b000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fb3de6af000)
```

```bash
$ ./deno testdata/001_hello.js
Hello World
```


This is similar to https://github.com/ry/deno/pull/16