### PR TITLE
Avoid apply and move arrayToStr to util

### DIFF
--- a/util.ts
+++ b/util.ts
@@ -23,6 +23,10 @@ export function typedArrayToArrayBuffer(ta: TypedArray): ArrayBuffer {
   return ab as ArrayBuffer;
 }
 
+export function arrayToStr(ui8: Uint8Array): string {
+  return String.fromCharCode(...ui8);
+}
+
 // A `Resolvable` is a Promise with the `reject` and `resolve` functions
 // placed as methods on the promise object itself. It allows you to do:
 //

--- a/v8_source_maps.ts
+++ b/v8_source_maps.ts
@@ -4,6 +4,7 @@
 // Originated from source-map-support but has been heavily modified for deno.
 import { SourceMapConsumer, MappedPosition } from "source-map";
 import * as base64 from "base64-js";
+import { arrayToStr } from "./util";
 
 const consumers = new Map<string, SourceMapConsumer>();
 
@@ -269,9 +270,4 @@ function mapEvalOrigin(origin: string): string {
 
   // Make sure we still return useful information if we didn't find anything
   return origin;
-}
-
-// TODO move to util?
-function arrayToStr(ui8: Uint8Array): string {
-  return String.fromCharCode.apply(null, ui8);
 }


### PR DESCRIPTION
# Summary

This PR is to remove one TODO and leverage the spread operator to replace the `apply` which is not performance friendly.