### PR TITLE
Correctly cache ccache build dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: c++
 cache:
   ccache: true
   directories:
-   - .cache/
-   - node_modules/
+   - $HOME/.ccache
+   - node_modules
    - $V8WORKER2_OUT_PATH
 env:
   global:


### PR DESCRIPTION
According to
https://docs.travis-ci.com/user/caching/#ccache-cache
We typically would want to do `cache: ccache` but since we are also
caching other dirs we have this option set manually.

However it looks like the ccache dir was not set to be relative to home,
which meant we were not getting any of the ccache cache wins across
builds (which can be seen in how long it takes to rebuild v8worker2 each
time)

---
⚠️ 
Since I am not an admin on travis I can not check the cache in the build options, but based on the logs this seems to be a reasonable low risk change that can be backed out if it results in 0 wins.


![image](https://user-images.githubusercontent.com/883126/40889547-4fd413e6-671d-11e8-960b-76ae05068fdd.png)

Right image shows the cache dir before the fix
Left shows the cache dir after the fix

This looks to be now what we want 💃 