### PR TITLE
Cleans the build before testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ fmt: node_modules
 	go fmt
 	clang-format msg.proto -i
 
-test: deno
+test: clean deno
 	go test -v
 
 .PHONY: test lint clean distclean


### PR DESCRIPTION
Now the `make test` command will not clean the build before testing, which makes testing failed if `msg.proto` has some incompatible changes before.