### PR TITLE
Move console to console.ts and better stringify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 TS_FILES = \
+	console.ts \
 	deno.d.ts \
 	deno.ts \
 	dispatch.ts \

--- a/console.ts
+++ b/console.ts
@@ -1,0 +1,33 @@
+const print = V8Worker2.print;
+
+// tslint:disable-next-line:no-any
+function stringifyArgs(args: any[]): string {
+  const out: string[] = [];
+  for (const a of args) {
+    if (typeof a === "string") {
+      out.push(a);
+    } else {
+      out.push(JSON.stringify(a));
+    }
+  }
+  return out.join(" ");
+}
+
+export const globalConsole = {
+  // tslint:disable-next-line:no-any
+  log(...args: any[]): void {
+    print(stringifyArgs(args));
+  },
+
+  // tslint:disable-next-line:no-any
+  error(...args: any[]): void {
+    print("ERROR: " + stringifyArgs(args));
+  },
+
+  // tslint:disable-next-line:no-any
+  assert(condition: boolean, ...args: any[]): void {
+    if (!condition) {
+      throw new Error("Assertion failed: " + stringifyArgs(args));
+    }
+  }
+};

--- a/console.ts
+++ b/console.ts
@@ -1,6 +1,5 @@
-class ConsoleContext {
-  seen = new Set<{}>();
-}
+// tslint:disable-next-line:no-any
+type ConsoleContext = Set<any>;
 
 // tslint:disable-next-line:no-any
 function stringify(ctx: ConsoleContext, value: any): string {
@@ -17,11 +16,11 @@ function stringify(ctx: ConsoleContext, value: any): string {
       if (value === null) {
         return "null";
       }
-      if (ctx.seen.has(value)) {
+      if (ctx.has(value)) {
         return "[Circular]";
       }
 
-      ctx.seen.add(value);
+      ctx.add(value);
 
       const keys = Object.keys(value);
       const keyStrings = [];
@@ -29,7 +28,7 @@ function stringify(ctx: ConsoleContext, value: any): string {
         keyStrings.push(`${key}: ${stringify(ctx, value[key])}`);
       }
 
-      ctx.seen.delete(value);
+      ctx.delete(value);
 
       if (keyStrings.length === 0) {
         return "{}";
@@ -48,7 +47,8 @@ function stringifyArgs(args: any[]): string {
     if (typeof a === "string") {
       out.push(a);
     } else {
-      out.push(stringify(new ConsoleContext(), a));
+      // tslint:disable-next-line:no-any
+      out.push(stringify(new Set<any>(), a));
     }
   }
   return out.join(" ");
@@ -64,7 +64,6 @@ export class Console {
 
   debug = this.log;
   info = this.log;
-  dirxml = this.log;
 
   // tslint:disable-next-line:no-any
   warn(...args: any[]): void {

--- a/console.ts
+++ b/console.ts
@@ -34,7 +34,7 @@ function stringify(ctx: ConsoleContext, value: any): string {
         if (valStrings.length === 0) {
           return "[]";
         }
-        return `[${valStrings.join(", ")}]`;
+        return `[ ${valStrings.join(", ")} ]`;
       } else {
         for (const key of Object.keys(value)) {
           valStrings.push(`${key}: ${stringify(ctx, value[key])}`);
@@ -79,7 +79,7 @@ export class Console {
 
   // tslint:disable-next-line:no-any
   warn(...args: any[]): void {
-    print("ERROR: " + stringifyArgs(args));
+    print(`ERROR: ${stringifyArgs(args)}`);
   }
 
   error = this.warn;
@@ -87,7 +87,7 @@ export class Console {
   // tslint:disable-next-line:no-any
   assert(condition: boolean, ...args: any[]): void {
     if (!condition) {
-      throw new Error("Assertion failed: " + stringifyArgs(args));
+      throw new Error(`Assertion failed: ${stringifyArgs(args)}`);
     }
   }
 }

--- a/console.ts
+++ b/console.ts
@@ -16,25 +16,37 @@ function stringify(ctx: ConsoleContext, value: any): string {
       if (value === null) {
         return "null";
       }
+
       if (ctx.has(value)) {
         return "[Circular]";
       }
 
       ctx.add(value);
+      const valStrings = [];
 
-      const keys = Object.keys(value);
-      const keyStrings = [];
-      for (const key of keys) {
-        keyStrings.push(`${key}: ${stringify(ctx, value[key])}`);
+      if (Array.isArray(value)) {
+        for (const el of value) {
+          valStrings.push(stringify(ctx, el));
+        }
+        
+        ctx.delete(value);
+        
+        if (valStrings.length === 0) {
+          return "[]";
+        }
+        return `[${valStrings.join(", ")}]`;
+      } else {
+        for (const key of Object.keys(value)) {
+          valStrings.push(`${key}: ${stringify(ctx, value[key])}`);
+        }
+
+        ctx.delete(value);
+
+        if (valStrings.length === 0) {
+          return "{}";
+        }
+        return `{ ${valStrings.join(", ")} }`;
       }
-
-      ctx.delete(value);
-
-      if (keyStrings.length === 0) {
-        return "{}";
-      }
-
-      return `{ ${keyStrings.join(", ")} }`;
     default:
       return "[Not Implemented]";
   }

--- a/console.ts
+++ b/console.ts
@@ -1,4 +1,45 @@
-const print = V8Worker2.print;
+class ConsoleContext {
+  seen = new Set<{}>();
+}
+
+// tslint:disable-next-line:no-any
+function stringify(ctx: ConsoleContext, value: any): string {
+  switch (typeof value) {
+    case "string":
+      return `"${value}"`;
+    case "number":
+    case "boolean":
+    case "undefined":
+      return String(value);
+    case "function":
+      return "[Function]";
+    case "object":
+      if (value === null) {
+        return "null";
+      }
+      if (ctx.seen.has(value)) {
+        return "[Circular]";
+      }
+
+      ctx.seen.add(value);
+
+      const keys = Object.keys(value);
+      const keyStrings = [];
+      for (const key of keys) {
+        keyStrings.push(`${key}: ${stringify(ctx, value[key])}`);
+      }
+
+      ctx.seen.delete(value);
+
+      if (keyStrings.length === 0) {
+        return "{}";
+      }
+
+      return `{ ${keyStrings.join(", ")} }`;
+    default:
+      return "[Not Implemented]";
+  }
+}
 
 // tslint:disable-next-line:no-any
 function stringifyArgs(args: any[]): string {
@@ -7,22 +48,30 @@ function stringifyArgs(args: any[]): string {
     if (typeof a === "string") {
       out.push(a);
     } else {
-      out.push(JSON.stringify(a));
+      out.push(stringify(new ConsoleContext(), a));
     }
   }
   return out.join(" ");
 }
 
-export const globalConsole = {
+const print = V8Worker2.print;
+
+export class Console {
   // tslint:disable-next-line:no-any
   log(...args: any[]): void {
     print(stringifyArgs(args));
-  },
+  }
+
+  debug = this.log;
+  info = this.log;
+  dirxml = this.log;
 
   // tslint:disable-next-line:no-any
-  error(...args: any[]): void {
+  warn(...args: any[]): void {
     print("ERROR: " + stringifyArgs(args));
-  },
+  }
+
+  error = this.warn;
 
   // tslint:disable-next-line:no-any
   assert(condition: boolean, ...args: any[]): void {
@@ -30,4 +79,4 @@ export const globalConsole = {
       throw new Error("Assertion failed: " + stringifyArgs(args));
     }
   }
-};
+}

--- a/globals.ts
+++ b/globals.ts
@@ -21,39 +21,8 @@ _global["setInterval"] = timer.setInterval;
 _global["clearTimeout"] = timer.clearTimer;
 _global["clearInterval"] = timer.clearTimer;
 
-const print = V8Worker2.print;
-
-_global["console"] = {
-  // tslint:disable-next-line:no-any
-  log(...args: any[]): void {
-    print(stringifyArgs(args));
-  },
-
-  // tslint:disable-next-line:no-any
-  error(...args: any[]): void {
-    print("ERROR: " + stringifyArgs(args));
-  },
-
-  // tslint:disable-next-line:no-any
-  assert(condition: boolean, ...args: any[]): void {
-    if (!condition) {
-      throw new Error("Assertion failed: " + stringifyArgs(args));
-    }
-  }
-};
-
-// tslint:disable-next-line:no-any
-function stringifyArgs(args: any[]): string {
-  const out: string[] = [];
-  for (const a of args) {
-    if (typeof a === "string") {
-      out.push(a);
-    } else {
-      out.push(JSON.stringify(a));
-    }
-  }
-  return out.join(" ");
-}
+import { globalConsole } from "./console";
+_global["console"] = globalConsole;
 
 import { fetch } from "./fetch";
 _global["fetch"] = fetch;

--- a/globals.ts
+++ b/globals.ts
@@ -21,8 +21,8 @@ _global["setInterval"] = timer.setInterval;
 _global["clearTimeout"] = timer.clearTimer;
 _global["clearInterval"] = timer.clearTimer;
 
-import { globalConsole } from "./console";
-_global["console"] = globalConsole;
+import { Console } from "./console";
+_global["console"] = new Console();
 
 import { fetch } from "./fetch";
 _global["fetch"] = fetch;

--- a/tests.ts
+++ b/tests.ts
@@ -88,6 +88,7 @@ test(function tests_console_stringify_circular() {
     nu: null,
     nested: nestedObj,
     emptyObj: {},
+    arr: [1, "s", false, null, nestedObj],
   };
 
   nestedObj.o = circularObj;

--- a/tests.ts
+++ b/tests.ts
@@ -55,3 +55,48 @@ test(async function tests_writeFileSync() {
   const actual = dec.decode(dataRead);
   assertEqual("Hello", actual);
 });
+
+test(function tests_console_assert() {
+  console.assert(true);
+
+  let hasThrown = false;
+  try {
+    console.assert(false);
+  } catch {
+    hasThrown = true;
+  }
+  assertEqual(hasThrown, true);
+});
+
+test(function tests_console_stringify_circular() {
+  // tslint:disable-next-line:no-any
+  const nestedObj: any = {
+    num: 1,
+    bool: true,
+    str: "a",
+    method() {},
+    un: undefined,
+    nu: null,
+  };
+
+  const circularObj = {
+    num: 2,
+    bool: false,
+    str: "b",
+    method() {},
+    un: undefined,
+    nu: null,
+    nested: nestedObj,
+    emptyObj: {},
+  };
+
+  nestedObj.o = circularObj;
+
+  try {
+    console.log(nestedObj);
+  } catch {
+    throw new Error(
+      "Expected no crash on circular object"
+    );
+  }
+});

--- a/tests.ts
+++ b/tests.ts
@@ -69,6 +69,16 @@ test(function tests_console_assert() {
 });
 
 test(function tests_console_stringify_circular() {
+  class Base {
+    a = 1;
+    m1() {}
+  }
+
+  class Extended extends Base {
+    b = 2;
+    m2() {}
+  }
+
   // tslint:disable-next-line:no-any
   const nestedObj: any = {
     num: 1,
@@ -77,6 +87,10 @@ test(function tests_console_stringify_circular() {
     method() {},
     un: undefined,
     nu: null,
+    arrowFunc: () => {},
+    extendedClass: new Extended(),
+    nFunc: new Function(),
+    extendedCstr: Extended,
   };
 
   const circularObj = {
@@ -89,12 +103,23 @@ test(function tests_console_stringify_circular() {
     nested: nestedObj,
     emptyObj: {},
     arr: [1, "s", false, null, nestedObj],
+    baseClass: new Base(),
   };
 
   nestedObj.o = circularObj;
 
   try {
+    console.log(1);
+    console.log("s");
+    console.log(false);
+    console.log(Symbol(1));
+    console.log(null);
+    console.log(undefined);
+    console.log(new Extended());
+    console.log(function f() {});
     console.log(nestedObj);
+    console.log(JSON);
+    console.log(console);
   } catch {
     throw new Error(
       "Expected no crash on circular object"


### PR DESCRIPTION
Moving console definition to own file `console.ts` and make it a class.
Replaced `JSON.stringify()` with custom `stringify()` to avoid crashing on circular objects and work with methods/functions by displaying `[Function]`.
Add some aliases to already implemented console methods.