### PR TITLE
[fix] run normally when script is empty 

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -137,3 +137,12 @@ func TestTestsTs(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 }
+
+func TestErrorFilename(t *testing.T) {
+	integrationTestSetup()
+	cmd := exec.Command(denoFn, "*errorName.ts")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal(err.Error())
+	}
+}

--- a/main.ts
+++ b/main.ts
@@ -49,6 +49,8 @@ let startCalled = false;
 
     const inputFn = argv[0];
     const mod = runtime.resolveModule(inputFn, `${cwd}/`);
-    mod.compileAndRun();
+    if (mod !== null) {
+      mod.compileAndRun();
+    }
   });
 };

--- a/runtime.ts
+++ b/runtime.ts
@@ -150,8 +150,7 @@ export function resolveModule(
   try {
     fetchResponse = os.codeFetch(moduleSpecifier, containingFile);
   } catch (e) {
-    // TODO Only catch "no such file or directory" errors. Need error codes.
-    return null;
+    throw Error(`Cannot find module '${containingFile}${moduleSpecifier}'`);
   }
   const { filename, sourceCode, outputCode } = fetchResponse;
   if (sourceCode.length === 0) {

--- a/runtime.ts
+++ b/runtime.ts
@@ -150,7 +150,8 @@ export function resolveModule(
   try {
     fetchResponse = os.codeFetch(moduleSpecifier, containingFile);
   } catch (e) {
-    throw Error(`Cannot find module '${containingFile}${moduleSpecifier}'`);
+    // TODO Only catch "no such file or directory" errors. Need error codes.
+    return null;
   }
   const { filename, sourceCode, outputCode } = fetchResponse;
   if (sourceCode.length === 0) {


### PR DESCRIPTION
<!-- Some descriptions about this PR -->
Add and handle the error thrown because of error module name.
Run normally when script file is empty.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test`  passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added