### PR TITLE
Implement readFile

### DIFF
--- a/deno.d.ts
+++ b/deno.d.ts
@@ -11,4 +11,6 @@ declare module "deno" {
     data: Uint8Array,
     perm: number
   ): void;
+
+  function readFile(filename: string): Promise<Uint8Array>;
 }

--- a/deno.ts
+++ b/deno.ts
@@ -3,4 +3,4 @@
 // Public deno module.
 // TODO get rid of deno.d.ts
 export { pub, sub } from "./dispatch";
-export { readFileSync, writeFileSync } from "./os";
+export { readFileSync, writeFileSync, readFile } from "./os";

--- a/main.ts
+++ b/main.ts
@@ -11,6 +11,7 @@ import * as util from "./util";
 
 import { initTimers } from "./timers";
 import { initFetch } from "./fetch";
+import { initOS } from "./os";
 
 // To control internal logging output
 // Set with the -debug command-line flag.
@@ -26,6 +27,7 @@ let startCalled = false;
 
   initTimers();
   initFetch();
+  initOS();
 
   dispatch.sub("start", (payload: Uint8Array) => {
     if (startCalled) {

--- a/msg.proto
+++ b/msg.proto
@@ -104,9 +104,9 @@ message Msg {
 
   // READ_FILE
   string read_file_req_filename = 140;
-  uint32 read_file_req_id = 141;
+  int32 read_file_req_id = 141;
 
   // READ_FILE_RES
   bytes read_file_res_data = 150;
-  uint32 read_file_res_id = 151;
+  int32 read_file_res_id = 151;
 }

--- a/msg.proto
+++ b/msg.proto
@@ -25,6 +25,8 @@ message Msg {
     READ_FILE_SYNC = 11;
     READ_FILE_SYNC_RES = 12;
     WRITE_FILE_SYNC = 13;
+    READ_FILE = 14;
+    READ_FILE_RES = 15;
   }
   Command command = 1;
 
@@ -99,4 +101,12 @@ message Msg {
   bytes write_file_sync_data = 131;
   uint32 write_file_sync_perm = 132;
   // write_file_sync_perm specified by https://godoc.org/os#FileMode
+
+  // READ_FILE
+  string read_file_req_filename = 140;
+  uint32 read_file_req_id = 141;
+
+  // READ_FILE_RES
+  bytes read_file_res_data = 150;
+  uint32 read_file_res_id = 151;
 }

--- a/os.go
+++ b/os.go
@@ -196,7 +196,7 @@ func WriteFileSync(filename string, data []byte, perm uint32) []byte {
 	return out
 }
 
-func ReadFile(filename string, id uint32) []byte {
+func ReadFile(filename string, id int32) []byte {
 	async(func() {
 		data, err := afero.ReadFile(fs, filename)
 		res := &Msg{

--- a/os.go
+++ b/os.go
@@ -208,7 +208,7 @@ func ReadFile(filename string, id uint32) []byte {
 		} else {
 			res.ReadFileResData = data
 		}
-		PubMsg("readFileRes", res)
+		PubMsg("os", res)
 	})
 
 	return nil;

--- a/os.ts
+++ b/os.ts
@@ -3,7 +3,7 @@
 import { ModuleInfo } from "./types";
 import { pubInternal, sub } from "./dispatch";
 import { main as pb } from "./msg.pb";
-import { assert } from "./util";
+import { assert, generateUniqueIdOnMap } from "./util";
 
 export function initOS(): void {
   sub("os", (payload: Uint8Array) => {
@@ -78,14 +78,11 @@ export function writeFileSync(
 
 const readFileRequests = new Map<number, ReadFileRequest>();
 
-// TODO replace with bigint
-let nextReadFileRequestId = 0;
-
 class ReadFileRequest {
   private readonly id: number;
   response: ReadFileResponse;
   constructor(public filename: string) {
-    this.id = nextReadFileRequestId++;
+    this.id = generateUniqueIdOnMap(readFileRequests);
     readFileRequests.set(this.id, this);
     this.response = new ReadFileResponse();
   }

--- a/tests.ts
+++ b/tests.ts
@@ -7,7 +7,7 @@
 // serving the deno project directory. Try this:
 //   http-server -p 4545 --cors .
 import { test, assert, assertEqual } from "./testing/testing.ts";
-import { readFileSync, writeFileSync } from "deno";
+import { readFileSync, writeFileSync, readFile } from "deno";
 
 test(async function tests_test() {
   assert(true);
@@ -54,4 +54,21 @@ test(async function tests_writeFileSync() {
   const dec = new TextDecoder("utf-8");
   const actual = dec.decode(dataRead);
   assertEqual("Hello", actual);
+});
+
+test(async function tests_readFile() {
+  try {
+    const data = await readFile("package.json");
+    if (!data.byteLength) {
+      throw Error(
+        `Expected positive value for data.byteLength ${data.byteLength}`
+      );
+    }
+    const decoder = new TextDecoder("utf-8");
+    const json = decoder.decode(data);
+    const pkg = JSON.parse(json);
+    assertEqual(pkg.name, "deno");
+  } catch (e) {
+    throw e;
+  }
 });

--- a/util.ts
+++ b/util.ts
@@ -51,3 +51,19 @@ export function createResolvable<T>(): Resolvable<T> {
   });
   return Object.assign(promise, methods) as Resolvable<T>;
 }
+
+const MAX_ID_AMOUNT = 0x7FFFFFFF;
+//tslint:disable-next-line:no-any
+export function generateUniqueIdOnMap(targetMap: Map<number, any>) {
+  if (targetMap.size >= MAX_ID_AMOUNT) {
+    throw new Error("Exceed max number limit");
+  }
+  let num;
+  while (true) {
+    num = Math.floor(Math.random() * (MAX_ID_AMOUNT + 1));
+    if (!targetMap.has(num)) {
+      break;
+    }
+  }
+  return num;
+}


### PR DESCRIPTION
Implement async version for readFile. Simulated `fetch` in its handling
May have problem with overflowing ids (to be fixed along with that of `fetch` in the future)