### PR TITLE
[feat] add recv function

### DIFF
--- a/dispatch.ts
+++ b/dispatch.ts
@@ -1,6 +1,6 @@
 // Copyright 2018 Ryan Dahl <ry@tinyclouds.org>
 // All rights reserved. MIT License.
-import { typedArrayToArrayBuffer, once } from "./util";
+import { typedArrayToArrayBuffer, onceStrict } from "./util";
 import { _global } from "./globals";
 import { main as pb } from "./msg.pb";
 
@@ -56,7 +56,7 @@ export function pubInternal(channel: string, obj: pb.IMsg): null | pb.Msg {
   }
 }
 
-export const recvMessage = once(() => {
+export const recvMessage = onceStrict(() => {
   V8Worker2.recv((ab: ArrayBuffer) => {
     const msg = pb.BaseMsg.decode(new Uint8Array(ab));
     const subscribers = channels.get(msg.channel);

--- a/main.ts
+++ b/main.ts
@@ -7,7 +7,7 @@ import { sub, recvMessage } from "./dispatch";
 import { main as pb } from "./msg.pb";
 
 import * as runtime from "./runtime";
-import { log, once } from "./util";
+import { log, onceStrict } from "./util";
 
 import { initTimers } from "./timers";
 import { initFetch } from "./fetch";
@@ -27,7 +27,7 @@ export let debug = false;
   initFetch();
   recvMessage();
 
-  sub("start", once((payload: Uint8Array) => {
+  sub("start", onceStrict((payload: Uint8Array) => {
       const msg = pb.Msg.decode(payload);
       const {
         startCwd: cwd,

--- a/main.ts
+++ b/main.ts
@@ -3,11 +3,11 @@
 // This allows us to have async/await in our code. It must be loaded first.
 import "babel-polyfill";
 
-import * as dispatch from "./dispatch";
+import { sub, recvMessage } from "./dispatch";
 import { main as pb } from "./msg.pb";
 
 import * as runtime from "./runtime";
-import * as util from "./util";
+import { log, once } from "./util";
 
 import { initTimers } from "./timers";
 import { initFetch } from "./fetch";
@@ -15,7 +15,6 @@ import { initFetch } from "./fetch";
 // To control internal logging output
 // Set with the -debug command-line flag.
 export let debug = false;
-let startCalled = false;
 
 // denoMain is needed to allow hooks into the system.
 // Also eventual snapshot support needs it.
@@ -26,29 +25,26 @@ let startCalled = false;
 
   initTimers();
   initFetch();
+  recvMessage();
 
-  dispatch.sub("start", (payload: Uint8Array) => {
-    if (startCalled) {
-      throw Error("start message received more than once!");
-    }
-    startCalled = true;
+  sub("start", once((payload: Uint8Array) => {
+      const msg = pb.Msg.decode(payload);
+      const {
+        startCwd: cwd,
+        startArgv: argv,
+        startDebugFlag: debugFlag,
+        startMainJs: mainJs,
+        startMainMap: mainMap
+      } = msg;
 
-    const msg = pb.Msg.decode(payload);
-    const {
-      startCwd: cwd,
-      startArgv: argv,
-      startDebugFlag: debugFlag,
-      startMainJs: mainJs,
-      startMainMap: mainMap
-    } = msg;
+      debug = debugFlag;
+      log("start", { cwd, argv, debugFlag });
 
-    debug = debugFlag;
-    util.log("start", { cwd, argv, debugFlag });
+      runtime.setup(mainJs, mainMap);
 
-    runtime.setup(mainJs, mainMap);
-
-    const inputFn = argv[0];
-    const mod = runtime.resolveModule(inputFn, `${cwd}/`);
-    mod.compileAndRun();
-  });
+      const inputFn = argv[0];
+      const mod = runtime.resolveModule(inputFn, `${cwd}/`);
+      mod.compileAndRun();
+    })
+  );
 };

--- a/testdata/error.ts.out
+++ b/testdata/error.ts.out
@@ -1,6 +1,6 @@
 /main.js:[WILDCARD]
-                throw _iteratorError;
-                ^
+                    throw _iteratorError;
+                    ^
 Error: bad
     at foo ([WILDCARD]testdata/error.ts:2:9)
     at bar ([WILDCARD]testdata/error.ts:6:3)
@@ -8,3 +8,5 @@ Error: bad
     at Object.eval [as globalEval] (<anonymous>)
     at execute (../runtime.ts:[WILDCARD])
     at FileModule.compileAndRun (../runtime.ts:[WILDCARD]
+    at ../main.ts:[WILDCARD]
+    at ../dispatch.ts:[WILDCARD]

--- a/util.ts
+++ b/util.ts
@@ -51,3 +51,19 @@ export function createResolvable<T>(): Resolvable<T> {
   });
   return Object.assign(promise, methods) as Resolvable<T>;
 }
+
+/* tslint:disable:no-any */
+export function once(fn: Function) {
+  let haveCalled = false;
+  let result: any;
+
+  return (...args: any[]) => {
+    if (haveCalled) {
+      throw Error("This function can only be called once");
+    }
+
+    haveCalled = true;
+    result = fn(...args);
+    return result;
+  };
+}

--- a/util.ts
+++ b/util.ts
@@ -2,6 +2,7 @@
 // All rights reserved. MIT License.
 import { debug } from "./main";
 import { TypedArray } from "./types";
+import { _global } from "globals";
 
 // Internal logging for deno. Use the "debug" variable above to control
 // output.
@@ -52,18 +53,19 @@ export function createResolvable<T>(): Resolvable<T> {
   return Object.assign(promise, methods) as Resolvable<T>;
 }
 
-/* tslint:disable:no-any */
-export function once(fn: Function) {
+/* tslint:disable: no-any */
+export function onceStrict(fn: Function, context?: any) {
   let haveCalled = false;
-  let result: any;
 
-  return (...args: any[]) => {
+  /* tslint:disable-next-line:only-arrow-functions */
+  return function (...args: any[]) {
     if (haveCalled) {
       throw Error("This function can only be called once");
     }
 
     haveCalled = true;
-    result = fn(...args);
-    return result;
+    // I cannot use fn.apply(context || this) 
+    // because the value of 'noImplicitThis" is true
+    return fn.apply(context || _global, args);
   };
 }


### PR DESCRIPTION
<!-- Some descriptions about this PR -->
I found the `V8Worker2.recv` was called redundantly when I import `dispach.ts`. In fact, what we want is calling `recv` just once when deno init, so I modify the code.
I also add an util function named `once`, because I find other cases where function just be called once, such as `sub("start")`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test`  passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added