### PR TITLE
Use template literals instead of traditional string concatenation

### DIFF
--- a/globals.ts
+++ b/globals.ts
@@ -31,13 +31,13 @@ _global["console"] = {
 
   // tslint:disable-next-line:no-any
   error(...args: any[]): void {
-    print("ERROR: " + stringifyArgs(args));
+    print(`ERROR: ${stringifyArgs(args)}`);
   },
 
   // tslint:disable-next-line:no-any
   assert(condition: boolean, ...args: any[]): void {
     if (!condition) {
-      throw new Error("Assertion failed: " + stringifyArgs(args));
+      throw new Error(`Assertion failed: ${stringifyArgs(args)}`);
     }
   }
 };

--- a/runtime.ts
+++ b/runtime.ts
@@ -181,7 +181,7 @@ function resolveModuleName(
 function execute(fileName: string, outputCode: string): void {
   util.assert(outputCode && outputCode.length > 0);
   _global["define"] = makeDefine(fileName);
-  outputCode += "\n//# sourceURL=" + fileName;
+  outputCode += `\n//# sourceURL=${fileName}`;
   globalEval(outputCode);
   _global["define"] = null;
 }

--- a/util.ts
+++ b/util.ts
@@ -14,7 +14,7 @@ export function log(...args: any[]): void {
 
 export function assert(cond: boolean, msg = "") {
   if (!cond) {
-    throw Error("Assert fail. " + msg);
+    throw Error(`Assert fail. ${msg}`);
   }
 }
 

--- a/v8_source_maps.ts
+++ b/v8_source_maps.ts
@@ -53,7 +53,7 @@ export function prepareStackTraceWrapper(
 
 export function prepareStackTrace(error: Error, stack: CallSite[]): string {
   const frames = stack.map(
-    (frame: CallSite) => "\n    at " + wrapCallSite(frame).toString()
+    (frame: CallSite) => `\n    at ${wrapCallSite(frame).toString()}`
   );
   return error.toString() + frames.join("");
 }
@@ -162,7 +162,7 @@ function CallSiteToString(frame: CallSite): string {
         functionName.indexOf("." + methodName) !==
           functionName.length - methodName.length - 1
       ) {
-        line += " [as " + methodName + "]";
+        line += ` [as ${ methodName} ]`;
       }
     } else {
       line += typeName + "." + (methodName || "<anonymous>");
@@ -176,7 +176,7 @@ function CallSiteToString(frame: CallSite): string {
     addSuffix = false;
   }
   if (addSuffix) {
-    line += " (" + fileLocation + ")";
+    line += ` (${fileLocation})`;
   }
   return line;
 }
@@ -265,7 +265,7 @@ function mapEvalOrigin(origin: string): string {
   // Parse nested eval() calls using recursion
   match = /^eval at ([^(]+) \((.+)\)$/.exec(origin);
   if (match) {
-    return "eval at " + match[1] + " (" + mapEvalOrigin(match[2]) + ")";
+    return `eval at ${match[1]} (${mapEvalOrigin(match[2])})`;
   }
 
   // Make sure we still return useful information if we didn't find anything


### PR DESCRIPTION
I rewrote a number of lines where traditional string concatenation was used in favor of the contemporary template literal syntax.