### PR TITLE
Implement Request

### DIFF
--- a/globals.ts
+++ b/globals.ts
@@ -55,8 +55,9 @@ function stringifyArgs(args: any[]): string {
   return out.join(" ");
 }
 
-import { fetch } from "./fetch";
+import { fetch, Request } from "./fetch";
 _global["fetch"] = fetch;
+_global["Request"] = Request;
 
 import { TextEncoder, TextDecoder } from "text-encoding";
 _global["TextEncoder"] = TextEncoder;


### PR DESCRIPTION
I'm just hacking around, might benefit from #148.
Also this approach passes an encoded JSON (which requires unmarshaling on the Go side).
Now it's possible to do stuff like:
```typescript
async function tests_fetch() {
    let req = new Request("http://httpbin.org/headers", {method: "GET"});
    const response = await fetch(req);
    const json = await response.json();
    console.log(json)
}
```
Feedback/ideas appreciated 👍 