### PR TITLE
Support tmpdir with process

### DIFF
--- a/deno.d.ts
+++ b/deno.d.ts
@@ -1,5 +1,7 @@
 // Copyright 2018 Ryan Dahl <ry@tinyclouds.org>
 // All rights reserved. MIT License.
+import {ProcessInfo} from "./types";
+
 declare module "deno" {
   type MessageCallback = (msg: Uint8Array) => void;
   function sub(channel: string, cb: MessageCallback): void;
@@ -11,4 +13,6 @@ declare module "deno" {
     data: Uint8Array,
     perm: number
   ): void;
+
+  function process(): ProcessInfo;
 }

--- a/deno.ts
+++ b/deno.ts
@@ -3,4 +3,4 @@
 // Public deno module.
 // TODO get rid of deno.d.ts
 export { pub, sub } from "./dispatch";
-export { readFileSync, writeFileSync } from "./os";
+export { readFileSync, writeFileSync, process } from "./os";

--- a/msg.proto
+++ b/msg.proto
@@ -25,6 +25,8 @@ message Msg {
     READ_FILE_SYNC = 11;
     READ_FILE_SYNC_RES = 12;
     WRITE_FILE_SYNC = 13;
+    OS_PROCESS = 20;
+    OS_PROCESS_RES = 21;
   }
   Command command = 1;
 
@@ -99,4 +101,9 @@ message Msg {
   bytes write_file_sync_data = 131;
   uint32 write_file_sync_perm = 132;
   // write_file_sync_perm specified by https://godoc.org/os#FileMode
+
+  // OS_PROCESS
+  string process_platform = 200;
+  string process_cwd = 201;
+  string process_tmp_dir = 202;
 }

--- a/os.go
+++ b/os.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"runtime"
 )
 
 const assetPrefix string = "/$asset$/"
@@ -41,6 +42,8 @@ func InitOS() {
 				msg.CodeCacheOutputCode)
 		case Msg_EXIT:
 			os.Exit(int(msg.ExitCode))
+		case Msg_OS_PROCESS:
+			return Process()
 		case Msg_READ_FILE_SYNC:
 			return ReadFileSync(msg.ReadFileSyncFilename)
 		case Msg_WRITE_FILE_SYNC:
@@ -188,6 +191,24 @@ func WriteFileSync(filename string, data []byte, perm uint32) []byte {
 	res := &Msg{}
 	if err != nil {
 		res.Error = err.Error()
+	}
+	out, err := proto.Marshal(res)
+	check(err)
+	return out
+}
+
+func Process() []byte{
+	cwd, err := os.Getwd()
+	res := &Msg{}
+	if err != nil {
+		res.Error = err.Error()
+	}else{
+		res = &Msg{
+			Command: Msg_OS_PROCESS_RES,
+			ProcessCwd: cwd,
+			ProcessPlatform: runtime.GOOS,
+			ProcessTmpDir: os.TempDir(),
+		}
 	}
 	out, err := proto.Marshal(res)
 	check(err)

--- a/os.ts
+++ b/os.ts
@@ -1,6 +1,6 @@
 // Copyright 2018 Ryan Dahl <ry@tinyclouds.org>
 // All rights reserved. MIT License.
-import { ModuleInfo } from "./types";
+import {ModuleInfo, ProcessInfo} from "./types";
 import { pubInternal } from "./dispatch";
 import { main as pb } from "./msg.pb";
 import { assert } from "./util";
@@ -62,4 +62,16 @@ export function writeFileSync(
     writeFileSyncData: data,
     writeFileSyncPerm: perm
   });
+}
+
+export function process(): ProcessInfo {
+  const res = pubInternal("os", {
+    command: pb.Msg.Command.OS_PROCESS,
+  });
+  assert(res.command === pb.Msg.Command.OS_PROCESS_RES);
+  return {
+      platform: res.processPlatform,
+      cwd: res.processCwd,
+      tmpDir: res.processTmpDir,
+  };
 }

--- a/tests.ts
+++ b/tests.ts
@@ -7,7 +7,7 @@
 // serving the deno project directory. Try this:
 //   http-server -p 4545 --cors .
 import { test, assert, assertEqual } from "./testing/testing.ts";
-import { readFileSync, writeFileSync } from "deno";
+import { readFileSync, writeFileSync, process } from "deno";
 
 test(async function tests_test() {
   assert(true);
@@ -47,11 +47,23 @@ test(async function tests_readFileSync() {
 test(async function tests_writeFileSync() {
   const enc = new TextEncoder();
   const data = enc.encode("Hello");
-  // TODO need ability to get tmp dir.
-  const fn = "/tmp/test.txt";
-  writeFileSync("/tmp/test.txt", data, 0o666);
-  const dataRead = readFileSync("/tmp/test.txt");
+  const proc = process();
+  // TODO: not support windows yet
+  const fn = proc.tmpDir.endsWith("/")
+      ? proc.tmpDir + "text.txt"
+      : proc.tmpDir +"/text.txt";
+  writeFileSync(fn, data, 0o666);
+  const dataRead = readFileSync(fn);
   const dec = new TextDecoder("utf-8");
   const actual = dec.decode(dataRead);
   assertEqual("Hello", actual);
+});
+
+test(async function tests_process() {
+  const {platform, cwd, tmpDir} = process();
+  assert(
+      ["darwin", "freebsd", "linux"].includes(platform),
+      "platform not exists: " + platform);
+  assert(cwd.length > 0, "get cwd failed");
+  assert(tmpDir.length >0, "get tempdir failed");
 });

--- a/types.ts
+++ b/types.ts
@@ -8,3 +8,9 @@ export interface ModuleInfo {
   sourceCode?: string;
   outputCode?: string;
 }
+
+export interface ProcessInfo {
+    platform?: string;
+    cwd?: string;
+    tmpDir?: string;
+}


### PR DESCRIPTION
I'm afraid my modification is too aggressive, I've added an OS process information getter function called `process()`, which can get the `platform`, `cwd` and `tmpdir` information. Those change will increase the `protobuf` item's code.
I chose the `20`, `21` to define `OS_PROCESS` and `OS_PROCESS_RES`.
 And I use `200` 
 represents the `process_platform`, `201` represents the `process_cwd`, `202` represents `process_tmp_dir`. If that modification is not suitable, I'm willing to change the code to suitable one.


Thanks for your time! :)
