### PR TITLE
Create issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,12 @@
+`deno` is in it's early development stage. The author is fucusing on validating the idea. At the moment non technical issues will be closed.
+
+If you want to propose a feature or suggest something technical, please check other issues and PRs first.
+
+If you want to know what the project is about refer to:
+
+- https://github.com/ry/deno#status
+- https://www.youtube.com/watch?v=M3BM9TB-8yA
+
+Thanks!
+
+<!-- **Please think twice before opening an issue.** -->


### PR DESCRIPTION
Added an issue template to give some guidance on creating issues.

I know people is also opening issues requesting help with setup, I did not address that in the template though because I have a suggestion. @ry if it's ok to you we could mark those with a label (i.e. `setup-help`) so you don't have to look at them but anybody who is willing to help with that can answer.

Also, I could add a PR template with required steps for PRs (i.e. adding tests).