### PR TITLE
Update tests copy

### DIFF
--- a/tests.ts
+++ b/tests.ts
@@ -2,7 +2,7 @@
 // All rights reserved. MIT License.
 // This test is executed as part of integration_test.go
 // But it can also be run manually:
-//  ./deno tests.ts
+//  ./deno --allow-net --allow-write tests.ts
 // There must also be a static file http server running on localhost:4545
 // serving the deno project directory. Try this:
 //   http-server -p 4545 --cors .


### PR DESCRIPTION
Running `./deno tests.ts` appears to throw error:
```bash
1/5 +0 -0: tests_test
2/5 +1 -0: tests_fetch
ERROR:
Test FAIL tests_fetch
deno(25333,0x700004868000) malloc: *** error for object 0xb276000: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
```
I ran with `./deno --allow-net --allow-write` instead and tests succeeded.
```bash
1/5 +0 -0: tests_test
2/5 +1 -0: tests_fetch
3/5 +2 -0: tests_console_assert
4/5 +3 -0: tests_readFileSync
5/5 +4 -0: tests_writeFileSync

DONE. Test passed: 5, failed: 0
```
Apologies if this is considered trivial but I thought this would be a helpful fix.
Thanks for your time regardless! Appreciate the work!