### PR TITLE
Change to TypeScript@next

### DIFF
--- a/deno2/js/package.json
+++ b/deno2/js/package.json
@@ -5,6 +5,6 @@
     "browserify": "^16.2.2",
     "protobufjs": "^6.8.6",
     "source-map-support": "^0.5.6",
-    "typescript": "next"
+    "typescript": "3.0.0-dev.20180609"
   }
 }

--- a/deno2/js/package.json
+++ b/deno2/js/package.json
@@ -5,6 +5,6 @@
     "browserify": "^16.2.2",
     "protobufjs": "^6.8.6",
     "source-map-support": "^0.5.6",
-    "typescript": "^2.9.1"
+    "typescript": "next"
   }
 }

--- a/deno2/js/yarn.lock
+++ b/deno2/js/yarn.lock
@@ -933,9 +933,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
+typescript@next:
+  version "3.0.0-dev.20180609"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.0-dev.20180609.tgz#e25f3377eef4bec04207168c9b57d9e94557b4e2"
 
 umd@^3.0.0:
   version "3.0.3"

--- a/deno2/js/yarn.lock
+++ b/deno2/js/yarn.lock
@@ -933,7 +933,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@next:
+typescript@3.0.0-dev.20180609:
   version "3.0.0-dev.20180609"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.0-dev.20180609.tgz#e25f3377eef4bec04207168c9b57d9e94557b4e2"
 


### PR DESCRIPTION
This PR is more advisory.  Once you get to dealing with throwing errors in TypeScript, you will encounter a bug in TypeScript 2.9.1 (and in theory 2.9.3 when it is released) that will throw an exception (See: Microsoft/TypeScript#24638).

This is now fixed in master and the daily builds of TypeScript, but hasn't been back ported.  Therefore migrating to `typescript@next` will utilise the daily builds of TypeScript and avoid the issue.