### PR TITLE
deno2: make parcel produce more modern javascript

### DIFF
--- a/deno2/BUILD.gn
+++ b/deno2/BUILD.gn
@@ -98,6 +98,7 @@ run_node("bundle") {
     "js/main.ts",
     "js/msg.pb.d.ts",
     "js/msg.pb.js",
+    "js/package.json", # `browserslist` field controls transform.
   ]
   outputs = [
     out_dir + "main.js",

--- a/deno2/js/package.json
+++ b/deno2/js/package.json
@@ -5,5 +5,8 @@
     "parcel-bundler": "^1.8.1",
     "protobufjs": "^6.8.6",
     "typescript": "^2.9.1"
-  }
+  },
+  "browserslist": [
+    "chrome 69"
+  ]
 }


### PR DESCRIPTION
Parcel runs typescript compiler output through babel. Unfortunately
there's no way to turn this off entirely, but with this rule it at least
won't transpile down to ES5.

See also https://github.com/parcel-bundler/parcel/issues/954