### PR TITLE
Fix building on Windows

### DIFF
--- a/deno2/README.md
+++ b/deno2/README.md
@@ -45,17 +45,18 @@ For linux you need these prereqs:
 
 First install the javascript deps.
 
-    cd js; yarn install
+    cd js && yarn install
 
 TODO(ry) Remove the above step by a deps submodule.
 
 Wrapper around the gclient/gn/ninja for end users. Try this first:
 
-    ./tools/build.py --use_ccache --debug
+    python ./tools/build.py --use_ccache --debug
 
-If that doesn't work, or you need more control, try calling gn manually:
+If that doesn't work, or you need more control, try calling gn manually (you'll
+need to set `DEPOT_TOOLS_WIN_TOOLCHAIN` to `0` on Windows):
 
-    gn gen out/Debug --args='cc_wrapper="ccache" is_debug=true '
+    gn gen out/Debug --args="cc_wrapper=\"ccache\" is_debug=true "
 
 Then build with ninja:
 

--- a/deno2/tools/build.py
+++ b/deno2/tools/build.py
@@ -23,6 +23,9 @@ def main():
     os.chdir(root_path)
     buildName = "Debug" if args.debug else "Default"
     buildDir = os.path.join(root_path, "out", buildName)
+    # Default to non-Googler configuration.
+    if 'DEPOT_TOOLS_WIN_TOOLCHAIN' not in os.environ:
+        os.environ['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
     # Run sync if any of the dep dirs don't exist.
     # Or the user supplied the --sync flag.
     if args.sync or dirsMissing():
@@ -47,7 +50,7 @@ def main():
 def run(args):
     print " ".join(args)
     env = os.environ.copy()
-    subprocess.check_call(args, env=env)
+    subprocess.check_call(args, env=env, shell=True)
 
 
 def dirsMissing():


### PR DESCRIPTION
- cmd doesn't support semicolons, use && instead.
- Run `python` explicitly.
- Use quote escaping that works in both bash and cmd.
- Set `DEPOT_TOOLS_WIN_TOOLCHAIN=0` by default (to avoid non-googlers
being asked for credentials).
- Pass `shell=True` to run .bat files.

See also: https://github.com/v8/node/pull/60