### PR TITLE
README: update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ gclient sync --no-history
 
 Install the javascript deps.
 
-    cd js; yarn install
-
-    cd -
+    (cd js; yarn install)
 
     gn gen out/Debug --args='cc_wrapper="ccache" is_debug=true '
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Install the javascript deps.
 
     cd js; yarn install
 
+    cd -
+
     gn gen out/Debug --args='cc_wrapper="ccache" is_debug=true '
 
 Then build with ninja (will take a while to complete):


### PR DESCRIPTION
If you follow the build instructions, `gn gen` fails because the `yarn` step changes the cwd.
To reproduce (tested on OS X and Linux):
```bash
$ cd js; yarn install
# This will run inside the js directory:
$ gn gen out/Debug --args='cc_wrapper="ccache" is_debug=true '
```
Output:
```python
Traceback (most recent call last):
  File "/Users/matias/dev/depot_tools/gn.py", line 48, in <module>
    sys.exit(main(sys.argv))
  File "/Users/matias/dev/depot_tools/gn.py", line 26, in main
    'gn', 'gn' + gclient_utils.GetExeSuffix())
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/posixpath.py", line 70, in join
    elif path == '' or path.endswith('/'):
```
Possible fix:
```bash
$ cd js; yarn install
# Go back to the src directory
$ cd -
$ gn gen out/Debug --args='cc_wrapper="ccache" is_debug=true '
```
Output:
```
Done. Made 151 targets from 81 files in 471ms
```
👍 