### PR TITLE
Generate //third_party/ and the symlinks from the script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,5 @@
 # npm deps
 node_modules
 
-# git deps
-/third_party/v8/
-/third_party/cpplint/
-/third_party/zlib/
-/third_party/rust_crates/libc/
-/third_party/flatbuffers/
-
-# gclient files
-/third_party/.gclient_entries
+# third party deps
+/third_party/

--- a/third_party/.gclient
+++ b/third_party/.gclient
@@ -1,1 +1,0 @@
-../gclient_config.py

--- a/third_party/googletest
+++ b/third_party/googletest
@@ -1,1 +1,0 @@
-v8/third_party/googletest

--- a/third_party/jinja2
+++ b/third_party/jinja2
@@ -1,1 +1,0 @@
-v8/third_party/jinja2

--- a/third_party/llvm-build
+++ b/third_party/llvm-build
@@ -1,1 +1,0 @@
-v8/third_party/llvm-build

--- a/third_party/markupsafe
+++ b/third_party/markupsafe
@@ -1,1 +1,0 @@
-v8/third_party/markupsafe

--- a/third_party/package.json
+++ b/third_party/package.json
@@ -1,1 +1,0 @@
-../package.json

--- a/third_party/yarn.lock
+++ b/third_party/yarn.lock
@@ -1,1 +1,0 @@
-../yarn.lock

--- a/tools/build_third_party.py
+++ b/tools/build_third_party.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# This script updates the third party dependencies of deno.
+# This script generates the third party dependencies of deno.
 # - Get Depot Tools and make sure it's in your path.
 #   http://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
 # - You need yarn installed as well.
@@ -8,14 +8,26 @@
 # Use //js/package.json to modify the npm deps.
 
 import os
+from os.path import join
 import subprocess
 
 root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-third_party_path = os.path.join(root_path, "third_party")
+third_party_path = join(root_path, "third_party")
 
 
 def main():
+    try:
+        os.makedirs(third_party_path)
+    except:
+        pass
     os.chdir(third_party_path)
+    remove_and_symlink(join("..", "gclient_config.py"), ".gclient")
+    remove_and_symlink(join("..", "package.json"), "package.json")
+    remove_and_symlink(join("..", "yarn.lock"), "yarn.lock")
+    remove_and_symlink(join("v8", "third_party", "googletest"), "googletest")
+    remove_and_symlink(join("v8", "third_party", "jinja2"), "jinja2")
+    remove_and_symlink(join("v8", "third_party", "llvm-build"), "llvm-build")
+    remove_and_symlink(join("v8", "third_party", "markupsafe"), "markupsafe")
     run(["gclient", "sync", "--no-history"])
     run(["yarn"])
 
@@ -24,6 +36,31 @@ def run(args):
     print " ".join(args)
     env = os.environ.copy()
     subprocess.check_call(args, env=env)
+
+
+def remove_and_symlink(target, name):
+    try:
+        os.unlink(name)
+    except:
+        pass
+    os.symlink(target, name)
+
+
+def symlink(target, name, target_is_dir=False):
+    if os.name == "nt":
+        import ctypes
+        CreateSymbolicLinkW = ctypes.windll.kernel32.CreateSymbolicLinkW
+        CreateSymbolicLinkW.restype = ctypes.c_ubyte
+        CreateSymbolicLinkW.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p,
+                                        ctypes.c_uint32)
+
+        flags = 0x02  # SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+        if (target_is_dir):
+            flags |= 0x01  # SYMBOLIC_LINK_FLAG_DIRECTORY
+        if not CreateSymbolicLinkW(name, target, flags):
+            raise ctypes.WinError()
+    else:
+        os.symlink(target, name)
 
 
 if '__main__' == __name__:


### PR DESCRIPTION
This PR is based on [the comment](https://github.com/ry/deno/pull/328#issuecomment-402462220) of Ryan in #328.

The script now creates `//third_party/` and sets up the symlinks in it, and then updates all gclient and npm deps.

I copied `symlink` function from `//js/run_node.py` for now. I'd like to leave the task of creating common utilities for later work because the layout of scripts seems incovenient to do it.

If this PR is merged, everyone needs to run `./tools/build_third_party.py` again.