### PR TITLE
Add 'command id' field to messages

### DIFF
--- a/src/handlers.h
+++ b/src/handlers.h
@@ -3,7 +3,9 @@
 #ifndef HANDLERS_H_
 #define HANDLERS_H_
 extern "C" {
-void handle_code_fetch(const char* module_specifier,
+#include <stdint.h>
+
+void handle_code_fetch(uint32_t cmd_id, const char* module_specifier,
                        const char* containing_file);
 }
 #endif  // HANDLERS_H_

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -17,6 +17,7 @@ fn test_example() {
 
 #[no_mangle]
 pub extern "C" fn handle_code_fetch(
+    cmd_id: u32,
     module_specifier: *const c_char,
     containing_file: *const c_char,
 ) {
@@ -24,8 +25,10 @@ pub extern "C" fn handle_code_fetch(
     let containing_file = string_from_ptr(containing_file);
 
     println!(
-        "handle_code_fetch. module_specifier = {} containing_file = {}",
-        module_specifier, containing_file
+        "handle_code_fetch. cmd_id = {} module_specifier = {} containing_file = {}",
+        cmd_id,
+        module_specifier,
+        containing_file
     );
 
     unimplemented!();

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -18,6 +18,7 @@ union Any {
 }
 
 table Base {
+  cmdId: uint32;
   error: string;
   msg: Any;
 }


### PR DESCRIPTION
This allows for correlating response messages to the command message that
caused them.