### PR TITLE
Use prettier in //third_party/node_modules

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+js/msg_generated.ts
+js/flatbuffers.js

--- a/js/os.ts
+++ b/js/os.ts
@@ -2,7 +2,7 @@
 // All rights reserved. MIT License.
 import { ModuleInfo } from "./types";
 import { deno as fbs } from "./msg_generated";
-import { assert, typedArrayToArrayBuffer  } from "./util";
+import { assert, typedArrayToArrayBuffer } from "./util";
 import { flatbuffers } from "flatbuffers";
 
 export function exit(exitCode = 0): void {
@@ -33,7 +33,7 @@ export function codeFetch(
   fbs.Base.addMsg(builder, msg);
   fbs.Base.addMsgType(builder, fbs.Any.CodeFetch);
   builder.finish(fbs.Base.endBase(builder));
-	const payload = typedArrayToArrayBuffer(builder.asUint8Array());
+  const payload = typedArrayToArrayBuffer(builder.asUint8Array());
   const resBuf = deno.send("x", payload);
 
   console.log("CodeFetch sent");
@@ -48,7 +48,7 @@ export function codeFetch(
     moduleName: codeFetchRes.moduleName(),
     filename: codeFetchRes.filename(),
     sourceCode: codeFetchRes.sourceCode(),
-    outputCode: codeFetchRes.outputCode(),
+    outputCode: codeFetchRes.outputCode()
   };
 }
 
@@ -76,7 +76,7 @@ export function codeCache(
   // Maybe need to do another step?
   // Base.finishBaseBuffer(builder, base);
 
-	const payload = typedArrayToArrayBuffer(builder.asUint8Array());
+  const payload = typedArrayToArrayBuffer(builder.asUint8Array());
   const resBuf = deno.send("x", payload);
   assert(resBuf === null);
 }
@@ -84,7 +84,7 @@ export function codeCache(
 export function readFileSync(filename: string): Uint8Array {
   assert(false, "Not Implemented");
   return null;
-	/*
+  /*
   const res = pubInternal("os", {
     command: fbs.Command.READ_FILE_SYNC,
     readFileSyncFilename: filename
@@ -99,7 +99,7 @@ export function writeFileSync(
   perm: number
 ): void {
   assert(false, "Not Implemented");
-	/*
+  /*
   pubInternal("os", {
     command: fbs.Command.WRITE_FILE_SYNC,
     writeFileSyncFilename: filename,

--- a/js/runtime.ts
+++ b/js/runtime.ts
@@ -149,7 +149,7 @@ export function resolveModule(
   util.assert(moduleSpecifier != null && moduleSpecifier.length > 0);
   // We ask golang to sourceCodeFetch. It will load the sourceCode and if
   // there is any outputCode cached, it will return that as well.
-	const fetchResponse = os.codeFetch(moduleSpecifier, containingFile);
+  const fetchResponse = os.codeFetch(moduleSpecifier, containingFile);
   const { filename, sourceCode, outputCode } = fetchResponse;
   if (sourceCode.length === 0) {
     return null;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@types/source-map-support": "^0.4.1",
     "flatbuffers": "^1.9.0",
     "parcel-bundler": "^1.8.1",
+    "prettier": "^1.13.7",
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.3.1",
     "tslint-no-circular-imports": "^0.5.0",

--- a/tools/format.py
+++ b/tools/format.py
@@ -5,6 +5,9 @@ from glob import glob
 from util import run
 
 root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+third_party_path = os.path.join(root_path, "third_party")
+prettier = os.path.join(third_party_path, "node_modules", "prettier",
+                        "bin-prettier.js")
 
 os.chdir(root_path)
 # TODO(ry) Install clang-format in third_party.
@@ -14,12 +17,6 @@ for fn in ["BUILD.gn", ".gn"] + glob("build_extra/**/*.gn*"):
     run(["gn", "format", fn])
 # TODO(ry) Install yapf in third_party.
 run(["yapf", "-i"] + glob("tools/*.py"))
-# TODO(ry) Install prettier in third_party.
-run([
-    "prettier", "--write", "js/deno.d.ts", "js/main.ts", "js/mock_runtime.js",
-    "tsconfig.json"
-])
-# Do not format these.
-#  js/msg_generated.ts
-#  js/flatbuffers.js
+run(["node", prettier, "--write"] + glob("js/*.js") + glob("js/*.ts") +
+    ["tsconfig.json"] + ["tslint.json"])
 run(["rustfmt", "-f", "--write-mode", "overwrite"] + glob("src/*.rs"))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2808,6 +2808,10 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
+prettier@^1.13.7:
+  version "1.13.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
+
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"


### PR DESCRIPTION
- Added prettier dependency in package.json
- Changed to use local version of prettier in format.py.
- Changed to use .prettierignore for ignoring certain files.