### PR TITLE
Add libdeno_nosnapshot source_set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,12 @@ install:
  - gn args $BUILD_PATH --list
  - ccache -s
  # Travis hangs without -j2 argument to ninja.
- - ninja -j2 -C $BUILD_PATH mock_runtime_test handlers_test deno_cc deno
+ - ninja -j2 -C $BUILD_PATH mock_runtime_test handlers_test deno_cc deno_cc_nosnapshot deno deno_nosnapshot
 script:
  - ./tools/lint.py
  - $BUILD_PATH/mock_runtime_test
  - $BUILD_PATH/handlers_test
  - $BUILD_PATH/deno_cc foo bar
+ - $BUILD_PATH/deno_cc_nosnapshot foo bar
  - $BUILD_PATH/deno meow
+ - $BUILD_PATH/deno_nosnapshot meow

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -152,9 +152,9 @@ source_set("libdeno_nosnapshot") {
     ":deno_bindings",
   ]
   configs += [ ":deno_config" ]
-  bt = get_target_outputs(":bundle")
-  bl = rebase_path(bt[0], root_build_dir)
-  defines = [ "BUNDLE_LOCATION=\"${bl}\"" ]
+  bundle_outputs = get_target_outputs(":bundle")
+  bundle_location = rebase_path(bundle_outputs[0])
+  defines = [ "BUNDLE_LOCATION=\"${bundle_location}\"" ]
 }
 
 # Due to bugs in Parcel we must run TSC independently in order to catch errors.

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -173,7 +173,7 @@ source_set("libdeno_nosnapshot") {
   configs += [ ":deno_config" ]
   bundle_outputs = get_target_outputs(":bundle")
   bundle_location = rebase_path(bundle_outputs[0])
-  defines = [ "BUNDLE_LOCATION=\"${bundle_location}\"" ]
+  defines = [ "BUNDLE_LOCATION=\"$bundle_location\"" ]
 }
 
 # Due to bugs in Parcel we must run TSC independently in order to catch errors.

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -15,9 +15,12 @@ config("deno_config") {
 rust_executable("deno") {
   source_root = "src/main.rs"
   extern = [ "$rust_build:libc" ]
-  deps = [
-    ":libdeno",
-  ]
+  deps = []
+  if (is_debug) {
+    deps += [ ":libdeno_nosnapshot" ]
+  } else {
+    deps += [ ":libdeno" ]
+  }
 }
 
 rust_staticlib("handlers") {
@@ -72,6 +75,17 @@ static_library("libdeno") {
   ]
   deps = [
     ":create_snapshot_deno",
+    ":deno_bindings",
+  ]
+  configs += [ ":deno_config" ]
+}
+
+source_set("libdeno_nosnapshot") {
+  sources = [
+    "src/from_filesystem.cc",
+  ]
+  deps = [
+    ":bundle",
     ":deno_bindings",
   ]
   configs += [ ":deno_config" ]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -58,7 +58,7 @@ executable("mock_runtime_test") {
   ]
   deps = [
     ":create_snapshot_mock_runtime",
-    ":deno_nosnapshot",
+    ":deno_bindings",
     "//testing/gtest:gtest",
   ]
   defines = [ "DENO_MOCK_RUNTIME" ]
@@ -72,12 +72,12 @@ static_library("libdeno") {
   ]
   deps = [
     ":create_snapshot_deno",
-    ":deno_nosnapshot",
+    ":deno_bindings",
   ]
   configs += [ ":deno_config" ]
 }
 
-v8_source_set("deno_nosnapshot") {
+v8_source_set("deno_bindings") {
   sources = [
     "src/binding.cc",
     "src/deno.h",
@@ -96,7 +96,7 @@ executable("snapshot_creator") {
     "src/snapshot_creator.cc",
   ]
   deps = [
-    ":deno_nosnapshot",
+    ":deno_bindings",
   ]
   configs += [ ":deno_config" ]
 }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -59,7 +59,6 @@ executable("deno_cc") {
 # This target is for fast incremental development.
 # When modifying the javascript runtime, this target will not go through the
 # extra process of building a snapshot and instead load the bundle from disk.
-
 executable("deno_cc_nosnapshot") {
   sources = [
     "src/main.cc",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -18,6 +18,9 @@ rust_executable("deno") {
   deps = [ ":libdeno" ]
 }
 
+# This target is for fast incremental development.
+# When modifying the javascript runtime, this target will not go through the
+# extra process of building a snapshot and instead load the bundle from disk.
 rust_executable("deno_nosnapshot") {
   source_root = "src/main.rs"
   extern = [ "$rust_build:libc" ]
@@ -48,6 +51,23 @@ executable("deno_cc") {
     ":flatbufferjs",
     ":handlers",
     ":libdeno",
+    ":msg_cpp",
+  ]
+  configs += [ ":deno_config" ]
+}
+
+# This target is for fast incremental development.
+# When modifying the javascript runtime, this target will not go through the
+# extra process of building a snapshot and instead load the bundle from disk.
+
+executable("deno_cc_nosnapshot") {
+  sources = [
+    "src/main.cc",
+  ]
+  deps = [
+    ":flatbufferjs",
+    ":handlers",
+    ":libdeno_nosnapshot",
     ":msg_cpp",
   ]
   configs += [ ":deno_config" ]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -15,12 +15,13 @@ config("deno_config") {
 rust_executable("deno") {
   source_root = "src/main.rs"
   extern = [ "$rust_build:libc" ]
-  deps = []
-  if (is_debug) {
-    deps += [ ":libdeno_nosnapshot" ]
-  } else {
-    deps += [ ":libdeno" ]
-  }
+  deps = [ ":libdeno" ]
+}
+
+rust_executable("deno_nosnapshot") {
+  source_root = "src/main.rs"
+  extern = [ "$rust_build:libc" ]
+  deps = [ ":libdeno_nosnapshot" ]
 }
 
 rust_staticlib("handlers") {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -81,17 +81,6 @@ static_library("libdeno") {
   configs += [ ":deno_config" ]
 }
 
-source_set("libdeno_nosnapshot") {
-  sources = [
-    "src/from_filesystem.cc",
-  ]
-  deps = [
-    ":bundle",
-    ":deno_bindings",
-  ]
-  configs += [ ":deno_config" ]
-}
-
 v8_source_set("deno_bindings") {
   sources = [
     "src/binding.cc",
@@ -152,6 +141,20 @@ run_node("bundle") {
     rebase_path(out_dir, root_build_dir),
     rebase_path("js/main.ts", root_build_dir),
   ]
+}
+
+source_set("libdeno_nosnapshot") {
+  sources = [
+    "src/from_filesystem.cc",
+  ]
+  deps = [
+    ":bundle",
+    ":deno_bindings",
+  ]
+  configs += [ ":deno_config" ]
+  bt = get_target_outputs(":bundle")
+  bl = rebase_path(bt[0], root_build_dir)
+  defines = [ "BUNDLE_LOCATION=\"${bl}\"" ]
 }
 
 # Due to bugs in Parcel we must run TSC independently in order to catch errors.

--- a/src/from_filesystem.cc
+++ b/src/from_filesystem.cc
@@ -1,0 +1,71 @@
+// Copyright 2018 Ryan Dahl <ry@tinyclouds.org>
+// All rights reserved. MIT License.
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+
+#include "third_party/v8/include/v8.h"
+#include "third_party/v8/src/base/logging.h"
+
+#include "deno.h"
+#include "file_util.h"
+#include "internal.h"
+
+namespace deno {
+
+std::vector<InternalFieldData*> deserialized_data;
+
+void DeserializeInternalFields(v8::Local<v8::Object> holder, int index,
+                               v8::StartupData payload, void* data) {
+  DCHECK_EQ(data, nullptr);
+  if (payload.raw_size == 0) {
+    holder->SetAlignedPointerInInternalField(index, nullptr);
+    return;
+  }
+  InternalFieldData* embedder_field = new InternalFieldData{0};
+  memcpy(embedder_field, payload.data, payload.raw_size);
+  holder->SetAlignedPointerInInternalField(index, embedder_field);
+  deserialized_data.push_back(embedder_field);
+}
+
+Deno* NewFromFileSystem(void* data, deno_recv_cb cb) {
+  // TODO(f-a-a) reference this dynamically somehow?
+  const char* js_filename = "./out/Debug/gen/bundle/main.js";
+  std::string js_source;
+  CHECK(deno::ReadFileToString(js_filename, &js_source));
+
+  Deno* d = new Deno;
+  d->currentArgs = nullptr;
+  d->cb = cb;
+  d->data = data;
+  v8::Isolate::CreateParams params;
+  params.array_buffer_allocator =
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+  params.external_references = external_references;
+  v8::Isolate* isolate = v8::Isolate::New(params);
+  AddIsolate(d, isolate);
+
+  v8::Locker locker(isolate);
+  v8::Isolate::Scope isolate_scope(isolate);
+  {
+    v8::HandleScope handle_scope(isolate);
+    auto context =
+        v8::Context::New(isolate, nullptr, v8::MaybeLocal<v8::ObjectTemplate>(),
+                         v8::MaybeLocal<v8::Value>(),
+                         v8::DeserializeInternalFieldsCallback(
+                             DeserializeInternalFields, nullptr));
+    InitializeContext(isolate, context, js_filename, js_source.c_str());
+    d->context.Reset(d->isolate, context);
+  }
+
+  return d;
+}
+
+}  // namespace deno
+
+extern "C" {
+Deno* deno_new(void* data, deno_recv_cb cb) {
+  return deno::NewFromFileSystem(data, cb);
+}
+}

--- a/src/from_filesystem.cc
+++ b/src/from_filesystem.cc
@@ -27,7 +27,6 @@ Deno* NewFromFileSystem(void* data, deno_recv_cb cb) {
   v8::Isolate::CreateParams params;
   params.array_buffer_allocator =
       v8::ArrayBuffer::Allocator::NewDefaultAllocator();
-  params.external_references = external_references;
   v8::Isolate* isolate = v8::Isolate::New(params);
   AddIsolate(d, isolate);
 

--- a/src/from_filesystem.cc
+++ b/src/from_filesystem.cc
@@ -30,10 +30,8 @@ void DeserializeInternalFields(v8::Local<v8::Object> holder, int index,
 }
 
 Deno* NewFromFileSystem(void* data, deno_recv_cb cb) {
-  // TODO(f-a-a) reference this dynamically somehow?
-  const char* js_filename = "./out/Debug/gen/bundle/main.js";
   std::string js_source;
-  CHECK(deno::ReadFileToString(js_filename, &js_source));
+  CHECK(deno::ReadFileToString(BUNDLE_LOCATION, &js_source));
 
   Deno* d = new Deno;
   d->currentArgs = nullptr;
@@ -55,7 +53,7 @@ Deno* NewFromFileSystem(void* data, deno_recv_cb cb) {
                          v8::MaybeLocal<v8::Value>(),
                          v8::DeserializeInternalFieldsCallback(
                              DeserializeInternalFields, nullptr));
-    InitializeContext(isolate, context, js_filename, js_source.c_str());
+    InitializeContext(isolate, context, BUNDLE_LOCATION, js_source.c_str());
     d->context.Reset(d->isolate, context);
   }
 

--- a/src/from_filesystem.cc
+++ b/src/from_filesystem.cc
@@ -30,6 +30,8 @@ void DeserializeInternalFields(v8::Local<v8::Object> holder, int index,
 }
 
 Deno* NewFromFileSystem(void* data, deno_recv_cb cb) {
+  printf("Reading javascript runtime bundle from " BUNDLE_LOCATION "\n");
+
   std::string js_source;
   CHECK(deno::ReadFileToString(BUNDLE_LOCATION, &js_source));
 


### PR DESCRIPTION
This PR attempts to solve #311.

I wouldn't expect for this PR to be merged right away, but this is a proof of concept I've been experimenting with after taking a stab at it.

This PR introduces a new `src/from_filesystem.cc` that is akin to `src/from_snapshot.cc` except that instead of initializing the v8 context with `StartupBlob_snapshot()`, it loads js from filesystem using the `InitializeContext` exposed in `internal.h`.

~It doesn't introduce a new target as @ry suggested in the issue. Instead, a `is_debug` check in `BUILD.gn` will conditionally build `libdeno_nosnapshot` if it is true.~
It does now!

Benchmarks when adding new `deno.print` to `main.ts` file:

```
master
ninja -v -C out/Debug deno  47.14s user 3.42s system 109% cpu 46.232 total
```

```
deno_nosnapshot
ninja -v -C out/Debug deno  9.82s user 1.27s system 139% cpu 7.947 total
```
<details><summary>master build log</summary><p>

```
ninja: Entering directory `out/Debug'
[1/1] ../../third_party/v8/buildtools/mac/gn --root=../.. -q gen .
[1/12] ccache ../../third_party/llvm-build/Release+Asserts/bin/clang++ -MMD -MF obj/deno_nosnapshot/binding.o.d -DV8_DEPRECATION_WARNINGS -DNO_TCMALLOC -DCHROMIUM_BUILD -DFIELDTRIAL_TESTING_ENABLED -D_LIBCPP_HAS_NO_ALIGNED_ALLOCATION -DCR_XCODE_VERSION=0941 -DCR_CLANG_REVISION=\"335864-1\" -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORE=0 -D_DEBUG -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DWTF_USE_DYNAMIC_ANNOTATIONS=1 -DDEBUG -DV8_ENABLE_CHECKS -DV8_EMBEDDER_STRING=\"-deno\" -DENABLE_DISASSEMBLER -DV8_TYPED_ARRAY_MAX_SIZE_IN_HEAP=64 -DENABLE_MINOR_MC -DOBJECT_PRINT -DVERIFY_HEAP -DV8_TRACE_MAPS -DV8_ENABLE_ALLOCATION_TIMEOUT -DV8_ENABLE_FORCE_SLOW_PATH -DV8_ENABLE_CHECKS -DENABLE_HANDLE_ZAPPING -DV8_USE_SNAPSHOT -DV8_CONCURRENT_MARKING -DV8_CHECK_MICROTASKS_SCOPES_CONSISTENCY -DV8_EMBEDDED_BUILTINS -DV8_TARGET_ARCH_X64 -DDEBUG -DDISABLE_UNTRUSTED_CODE_MITIGATIONS -I../.. -Igen -I../../third_party/v8 -I../../third_party/v8/include -Igen/third_party/v8/include -fno-strict-aliasing -fstack-protector-strong -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -fcolor-diagnostics -fmerge-all-constants -Xclang -mllvm -Xclang -instcombine-lower-dbg-declare=0 -no-canonical-prefixes -arch x86_64 -Wall -Wextra -Wimplicit-fallthrough -Wthread-safety -Wunguarded-availability -Wno-missing-field-initializers -Wno-unused-parameter -Wno-c++11-narrowing -Wno-covered-switch-default -Wno-unneeded-internal-declaration -Wno-undefined-var-template -Wno-address-of-packed-member -Wno-nonportable-include-path -Wno-user-defined-warnings -Wno-unused-lambda-capture -Wno-null-pointer-arithmetic -Wno-enum-compare-switch -Wno-ignored-pragma-optimize -fno-omit-frame-pointer -g1 -isysroot ../../../../../../Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=10.9.0 -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wmissing-field-initializers -Winconsistent-missing-override -Wunreachable-code -Wshorten-64-to-32 -O3 -fvisibility=default -Wno-undefined-bool-conversion -Wno-tautological-undefined-compare -std=c++14 -stdlib=libc++ -fno-exceptions -fno-rtti -c ../../src/binding.cc -o obj/deno_nosnapshot/binding.o
[2/12] touch obj/deno_nosnapshot.stamp
[3/12] TOOL_VERSION=1530535641 ../../build/toolchain/mac/linker_driver.py ../../third_party/llvm-build/Release+Asserts/bin/clang++  -stdlib=libc++ -arch x86_64 -segprot PROTECTED_MEMORY rw r -isysroot ../../../../../../Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=10.9.0 -Wl,-ObjC -o "./snapshot_creator" -Wl,-filelist,"./snapshot_creator.rsp"
[4/12] python ../../tools/run_node.py ./node_modules/typescript/bin/tsc --project ../../tsconfig.json --outDir gen/tsc_dist/
node ./node_modules/typescript/bin/tsc --project ../../tsconfig.json --outDir gen/tsc_dist/
[5/12] touch obj/run_tsc.stamp
[6/12] python ../../tools/run_node.py ./node_modules/parcel-bundler/bin/cli.js build --no-minify --out-dir gen/bundle/ ../../js/main.ts

<REDACTED>
✨  Built in 4.12s.

gen/bundle/main.js     ⚠️  6.7 MB    5.77s
gen/bundle/main.map          0 B    6.45s
node ./node_modules/parcel-bundler/bin/cli.js build --no-minify --out-dir gen/bundle/ ../../js/main.ts
[7/12] touch obj/bundle.stamp
[8/12] python ../../third_party/v8/tools/run.py /Users/Faris/Forks/deno/out/Debug/snapshot_creator gen/bundle/main.js gen/snapshot_deno.cc
[9/12] touch obj/create_snapshot_deno.stamp
[10/12] ccache ../../third_party/llvm-build/Release+Asserts/bin/clang++ -MMD -MF obj/libdeno/from_snapshot.o.d -DV8_DEPRECATION_WARNINGS -DNO_TCMALLOC -DCHROMIUM_BUILD -DFIELDTRIAL_TESTING_ENABLED -D_LIBCPP_HAS_NO_ALIGNED_ALLOCATION -DCR_XCODE_VERSION=0941 -DCR_CLANG_REVISION=\"335864-1\" -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORE=0 -D_DEBUG -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DWTF_USE_DYNAMIC_ANNOTATIONS=1 -DDEBUG -DV8_ENABLE_CHECKS -I../.. -Igen -I../../third_party/v8 -I../../third_party/v8/include -Igen/third_party/v8/include -fno-strict-aliasing -fstack-protector-strong -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -fcolor-diagnostics -fmerge-all-constants -Xclang -mllvm -Xclang -instcombine-lower-dbg-declare=0 -no-canonical-prefixes -arch x86_64 -Wall -Wextra -Wimplicit-fallthrough -Wthread-safety -Wunguarded-availability -Wno-missing-field-initializers -Wno-unused-parameter -Wno-c++11-narrowing -Wno-covered-switch-default -Wno-unneeded-internal-declaration -Wno-undefined-var-template -Wno-address-of-packed-member -Wno-nonportable-include-path -Wno-user-defined-warnings -Wno-unused-lambda-capture -Wno-null-pointer-arithmetic -Wno-enum-compare-switch -Wno-ignored-pragma-optimize -O0 -fno-omit-frame-pointer -g1 -isysroot ../../../../../../Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=10.9.0 -fvisibility=hidden -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wno-undefined-bool-conversion -Wno-tautological-undefined-compare -std=c++14 -stdlib=libc++ -fno-exceptions -fno-rtti -fvisibility-inlines-hidden -c ../../src/from_snapshot.cc -o obj/libdeno/from_snapshot.o
[11/12] rm -f obj/libdeno.a && TOOL_VERSION=1530535641 python ../../build/toolchain/mac/filter_libtool.py libtool -static  -o obj/libdeno.a -filelist obj/libdeno.a.rsp
[12/12] TOOL_VERSION=1530535641 ../../build/toolchain/mac/linker_driver.py ../../third_party/llvm-build/Release+Asserts/bin/clang++  -stdlib=libc++ -arch x86_64 -segprot PROTECTED_MEMORY rw r -isysroot ../../../../../../Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=10.9.0 -Wl,-ObjC -o "./deno" -Wl,-filelist,"./deno.rsp"  obj/deno_bin.o -lresolv obj/build_extra/rust/stdlib.a obj/build_extra/rust/liblibc.rlib
```

</p></details>

<details><summary>deno_nosnapshot build log</summary><p>

```
ninja: Entering directory `out/Debug'
[1/1] ../../third_party/v8/buildtools/mac/gn --root=../.. -q gen .
[1/7] python ../../tools/run_node.py ./node_modules/typescript/bin/tsc --project ../../tsconfig.json --outDir gen/tsc_dist/
node ./node_modules/typescript/bin/tsc --project ../../tsconfig.json --outDir gen/tsc_dist/
[2/7] touch obj/run_tsc.stamp
[3/7] python ../../tools/run_node.py ./node_modules/parcel-bundler/bin/cli.js build --no-minify --out-dir gen/bundle/ ../../js/main.ts

<REDACTED>
✨  Built in 4.00s.

gen/bundle/main.js     ⚠️  6.7 MB    5.68s
gen/bundle/main.map          0 B    6.39s
node ./node_modules/parcel-bundler/bin/cli.js build --no-minify --out-dir gen/bundle/ ../../js/main.ts
[4/7] touch obj/bundle.stamp
[5/7] ccache ../../third_party/llvm-build/Release+Asserts/bin/clang++ -MMD -MF obj/libdeno_nosnapshot/from_filesystem.o.d -DV8_DEPRECATION_WARNINGS -DNO_TCMALLOC -DCHROMIUM_BUILD -DFIELDTRIAL_TESTING_ENABLED -D_LIBCPP_HAS_NO_ALIGNED_ALLOCATION -DCR_XCODE_VERSION=0941 -DCR_CLANG_REVISION=\"335864-1\" -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORE=0 -D_DEBUG -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DWTF_USE_DYNAMIC_ANNOTATIONS=1 -DDEBUG -DV8_ENABLE_CHECKS -I../.. -Igen -I../../third_party/v8 -I../../third_party/v8/include -Igen/third_party/v8/include -fno-strict-aliasing -fstack-protector-strong -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -fcolor-diagnostics -fmerge-all-constants -Xclang -mllvm -Xclang -instcombine-lower-dbg-declare=0 -no-canonical-prefixes -arch x86_64 -Wall -Wextra -Wimplicit-fallthrough -Wthread-safety -Wunguarded-availability -Wno-missing-field-initializers -Wno-unused-parameter -Wno-c++11-narrowing -Wno-covered-switch-default -Wno-unneeded-internal-declaration -Wno-undefined-var-template -Wno-address-of-packed-member -Wno-nonportable-include-path -Wno-user-defined-warnings -Wno-unused-lambda-capture -Wno-null-pointer-arithmetic -Wno-enum-compare-switch -Wno-ignored-pragma-optimize -O0 -fno-omit-frame-pointer -g1 -isysroot ../../../../../../Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=10.9.0 -fvisibility=hidden -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wno-undefined-bool-conversion -Wno-tautological-undefined-compare -std=c++14 -stdlib=libc++ -fno-exceptions -fno-rtti -fvisibility-inlines-hidden -c ../../src/from_filesystem.cc -o obj/libdeno_nosnapshot/from_filesystem.o
[6/7] touch obj/libdeno_nosnapshot.stamp
[7/7] TOOL_VERSION=1530535641 ../../build/toolchain/mac/linker_driver.py ../../third_party/llvm-build/Release+Asserts/bin/clang++  -stdlib=libc++ -arch x86_64 -segprot PROTECTED_MEMORY rw r -isysroot ../../../../../../Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=10.9.0 -Wl,-ObjC -o "./deno" -Wl,-filelist,"./deno.rsp"  obj/deno_bin.o -lresolv obj/build_extra/rust/stdlib.a obj/build_extra/rust/liblibc.rlib
```

</p></details>

### Footnote ###
Currently `js_filename` reference is hard coded to `./out/Debug/gen/bundle/main.js`. I'm sure there is a smarter way of obtaining the bundle path.

I would gladly make the necessary changes to have this PR merged if the concept is sound, otherwise I hope this could be an inspiration for others to work on it!