### PR TITLE
Force Unix EOLs, to prevent Windows from breaking them.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Auto-detect text files.
+* text=auto
+
+# Force Unix EOLs, to prevent Windows from breaking them.
+*.* text eol=lf


### PR DESCRIPTION
Everything's in the title.