### PR TITLE
Use Cargo.toml to fetch cargo crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ install:
  - curl -sSf https://sh.rustup.rs | sh -s -- -y
  - export PATH=$HOME/.cargo/bin:$PATH
  - rustc --version
+ # ./tools/fetch_cargo_crates.py depends on this subcommand (https://github.com/ehuss/cargo-clone-crate)
+ - cargo install cargo-clone-crate
  - ./tools/build_third_party.py
  # ccache needs the custom LLVM to be in PATH and other variables.
  - export PATH=`pwd`/third_party/llvm-build/Release+Asserts/bin:$PATH

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,7 @@ authors = "Ryan Dahl <ry@tinyclouds.org>"
 
 [dependencies]
 libc = "0.2.42"
+url = "1.7.1"
+matches = "0.1.6"
+unicode-bidi = "0.3.4"
+unicode-normalization = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "deno"
+version = "0.1.0"
+authors = "Ryan Dahl <ry@tinyclouds.org>"
+
+[dependencies]
+libc = "0.2.42"

--- a/build_extra/rust/BUILD.gn
+++ b/build_extra/rust/BUILD.gn
@@ -22,7 +22,7 @@ rust_component("libc") {
 }
 
 rust_component("url") {
-  source_root = "$crates/url/src/lib.rs"
+  source_root = "$crates/rust-url/src/lib.rs"
   extern = [
     ":matches",
     ":idna",
@@ -31,7 +31,7 @@ rust_component("url") {
 }
 
 rust_component("percent_encoding") {
-  source_root = "$crates/url/percent_encoding/lib.rs"
+  source_root = "$crates/rust-url/percent_encoding/lib.rs"
 }
 
 rust_component("matches") {
@@ -39,7 +39,7 @@ rust_component("matches") {
 }
 
 rust_component("idna") {
-  source_root = "$crates/url/idna/src/lib.rs"
+  source_root = "$crates/rust-url/idna/src/lib.rs"
   extern = [
     ":matches",
     ":unicode_bidi",

--- a/gclient_config.py
+++ b/gclient_config.py
@@ -36,30 +36,7 @@ solutions = [{
     'flatbuffers'
 }, {
     'url':
-    'https://github.com/rust-lang/libc.git@8a85d662b90c14d458bc4ae9521a05564e20d7ae',
+    'https://github.com/avakar/pytoml.git@cb92445ca769b3966b3976cd69f5140761f15843',
     'name':
-    'rust_crates/libc'
-}, {
-    'url':
-    'https://github.com/servo/rust-url.git@fbe5e50316105482dcd53d2dabb148c445a5f4cd',
-    'name':
-    'rust_crates/url'
-}, {
-    # Needed for url.
-    'url':
-    'https://github.com/SimonSapin/rust-std-candidates.git@88a017b79ea146d6fde389c96982fc7518ba98bf',
-    'name':
-    'rust_crates/rust-std-candidates'
-}, {
-    # Needed for url.
-    'url':
-    'https://github.com/servo/unicode-bidi.git@32c81729db0ac90289ebeca9e0d4886f264e724d',
-    'name':
-    'rust_crates/unicode-bidi'
-}, {
-    # Needed for url.
-    'url':
-    'https://github.com/behnam/rust-unicode-normalization.git@3898e77b110246cb7243bf29b896c58d8975304a',
-    'name':
-    'rust_crates/unicode-normalization'
+    'pytoml'
 }]

--- a/tools/build_third_party.py
+++ b/tools/build_third_party.py
@@ -14,6 +14,7 @@ from util import run, remove_and_symlink
 
 root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 third_party_path = join(root_path, "third_party")
+tools_path = join(root_path, "tools")
 
 try:
     os.makedirs(third_party_path)
@@ -30,3 +31,4 @@ remove_and_symlink(join("v8", "third_party", "llvm-build"), "llvm-build")
 remove_and_symlink(join("v8", "third_party", "markupsafe"), "markupsafe")
 run(["gclient", "sync", "--shallow", "--no-history"])
 run(["yarn"])
+run(["python", join(tools_path, "fetch_cargo_crates.py")])

--- a/tools/build_third_party.py
+++ b/tools/build_third_party.py
@@ -21,6 +21,7 @@ except:
     pass
 os.chdir(third_party_path)
 remove_and_symlink(join("..", "gclient_config.py"), ".gclient")
+remove_and_symlink(join("..", "Cargo.toml"), "Cargo.toml")
 remove_and_symlink(join("..", "package.json"), "package.json")
 remove_and_symlink(join("..", "yarn.lock"), "yarn.lock")
 remove_and_symlink(join("v8", "third_party", "googletest"), "googletest")

--- a/tools/fetch_cargo_crates.py
+++ b/tools/fetch_cargo_crates.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# Inspired by
+# https://fuchsia.googlesource.com/build/+/master/rust/list_3p_crates.py
+# https://fuchsia.googlesource.com/build/+/master/rust/compile_3p_crates.py
+# Copyright 2018 The Fuchsia Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import os
+from os.path import join, dirname, realpath
+import sys
+import subprocess
+
+root_path = dirname(dirname(realpath(__file__)))
+third_party_path = join(root_path, "third_party")
+
+sys.path += [join(third_party_path, "pytoml")]
+import pytoml
+
+def run_command(args, env, cwd):
+    job = subprocess.Popen(args, env=env, cwd=cwd, stdout=subprocess.PIPE,
+                           stderr=subprocess.PIPE)
+    stdout, stderr = job.communicate()
+    return (job.returncode, stdout, stderr)
+
+def clone_crate(name, version):
+    call_args = [
+        "cargo", "clone",
+        "%s:%s" % (name, version)
+    ]
+    env = os.environ.copy()
+    _, _, stderr = run_command(
+        call_args,
+        env,
+        join(third_party_path, "rust_crates")
+    )
+    print(stderr)
+
+def main():
+    cargo_toml_path = join(third_party_path, "Cargo.toml")
+    with open(cargo_toml_path, "r") as file:
+        cargo_toml = pytoml.load(file)
+        for key, value in cargo_toml["dependencies"].items():
+            if type(value) is dict:
+                git = value.get("git")
+                clone_crate(key, git)
+            else:
+                clone_crate(key, value)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/fetch_cargo_crates.py
+++ b/tools/fetch_cargo_crates.py
@@ -24,6 +24,9 @@ def run_command(args, env, cwd):
     return (job.returncode, stdout, stderr)
 
 def clone_crate(name, version):
+    rust_crates_path = join(third_party_path, "rust_crates")
+    if not os.path.exists(rust_crates_path):
+        os.makedirs(rust_crates_path)
     call_args = [
         "cargo", "clone",
         "%s:%s" % (name, version)


### PR DESCRIPTION
This PR attempts to solve #366.

As noted by @robbym, `cargo install` works by downloading sources to a temporary directory, compiles it and output binaries which in our case that's a step ahead since we wanted to rely on `//build_extra/rust/BUILD.gn` for building. (p.s: if i understand Rust correctly...)

Here, I'm proposing to introduce a `fetch_cargo_crates.py` script that I got cues from Fuschia's codebase: [list_3p_crates.py](https://fuchsia.googlesource.com/build/+/master/rust/list_3p_crates.py) and [compile_3p_crates.py](https://fuchsia.googlesource.com/build/+/master/rust/compile_3p_crates.py).

To briefly explain the flow of operation:
1. Running `./tools/build_third_party.py`
   * symlinks `Cargo.toml` from the root dir to `third_party` dir
   * executes `fetch_cargo_crates.py`
2. `./tools/fetch_cargo_crates.py` will
   * parse `Cargo.toml` using `pytoml` library (pulled in via gclient)
   * extract crate name and crate version (with special handling for git defined crates)
   * call cargo clone with cargo name and crate version
   * and finally outputs cloned repositories to `third_party/rust_crates`

### Caveats
* No `Cargo.lock` is generated
* A cargo subcommand needs to be added (i.e. https://github.com/ehuss/cargo-clone-crate)
  * Installing seems to take some time... 🙍 
  * I opted to use this rather than [cargo-clone](https://github.com/JanLikar/cargo-clone) since it is recently published and potentially more maintained.
* `clone_crate` function within the `fetch_cargo_crates.py` script is rather brittle, it doesn't handle most of `Cargo.toml` semantics.

### Alternative
I have also made an alternative implementation in [`build_extra/rust/BUILD.gn`](https://github.com/ry/deno/blob/master/build_extra/rust/BUILD.gn#L7)... but can't seem to get it working in the build step, only in gen step. I discarded the idea since it felt out of place to pull dependencies during the gen step. But if you are interested to see the changes: it's here [f-a-a/cargo_fetch2](https://github.com/ry/deno/compare/master...f-a-a:cargo_fetch2?expand=1)

Outputs like this instead:
<img width="841" alt="screen shot 2018-07-16 at 03 50 11" src="https://user-images.githubusercontent.com/19421765/42737798-6e559d4e-88ab-11e8-993c-374bc1791eac.png">

cc: @ry @robbym  