### PR TITLE
Remove handlers crate target.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -2,6 +2,7 @@
 import("//third_party/v8/gni/v8.gni")
 import("//third_party/v8/snapshot_toolchain.gni")
 import("//build_extra/flatbuffers/flatbuffer.gni")
+import("//build_extra/flatbuffers/rust/rust_flatbuffer.gni")
 import("//build_extra/deno.gni")
 import("//build_extra/rust/rust.gni")
 
@@ -10,8 +11,8 @@ group("all") {
   deps = [
     ":deno",
     ":deno_ns",
-    ":handlers_test",
     ":test_cc",
+    ":test_rs",
   ]
 }
 
@@ -33,12 +34,29 @@ config("deno_config") {
   }
 }
 
+main_extern = [
+  "$rust_build:libc",
+  "$rust_build:log",
+  "$rust_build:url",
+  "//build_extra/flatbuffers/rust:flatbuffers",
+  ":msg_rs",
+
+  # Indirect rust depdendencies also need to be listed here:
+  # * Linking to `:handlers` or `:libdeno` isn't possible, because they
+  #   already contain some symbols exported by `handlers.rs`. These duplicate
+  #   symbols trip up the linker.
+  # * The `rust_test` and `rust_executable` templates only produce an object
+  #   file, and then invoke an external linker. Transitive rust depencenies
+  #   are not resolved in either step.
+  "$rust_build:idna",
+  "$rust_build:percent_encoding",
+  "$rust_build:unicode_bidi",
+  "$rust_build:unicode_normalization",
+]
+
 rust_executable("deno") {
   source_root = "src/main.rs"
-  extern = [
-    "$rust_build:libc",
-    "$rust_build:log",
-  ]
+  extern = main_extern
   deps = [
     ":libdeno",
   ]
@@ -50,43 +68,15 @@ rust_executable("deno") {
 # ns = no snapshot
 rust_executable("deno_ns") {
   source_root = "src/main.rs"
-  extern = [
-    "$rust_build:libc",
-    "$rust_build:log",
-  ]
+  extern = main_extern
   deps = [
     ":libdeno_nosnapshot",
   ]
 }
 
-rust_staticlib("handlers") {
-  source_root = "src/handlers.rs"
-  extern = [
-    "$rust_build:libc",
-    "$rust_build:url",
-    "$rust_build:log",
-  ]
-}
-
-rust_test("handlers_test") {
-  source_root = "src/handlers.rs"
-  extern = [
-    "$rust_build:libc",
-    "$rust_build:url",
-    "$rust_build:log",
-
-    # Indirect rust depdendencies also need to be listed here:
-    # * Linking to `:handlers` or `:libdeno` isn't possible, because they
-    #   already contain some symbols exported by `handlers.rs`. These duplicate
-    #   symbols trip up the linker.
-    # * The `rust_test` and `rust_executable` templates only produce an object
-    #   file, and then invoke an external linker. Transitive rust depencenies
-    #   are not resolved in either step.
-    "$rust_build:idna",
-    "$rust_build:percent_encoding",
-    "$rust_build:unicode_bidi",
-    "$rust_build:unicode_normalization",
-  ]
+rust_test("test_rs") {
+  source_root = "src/main.rs"
+  extern = main_extern
   deps = [
     ":deno_bindings",
   ]
@@ -100,8 +90,7 @@ executable("test_cc") {
   ]
   deps = [
     ":deno_base_test",
-    ":deno_bindings",
-    ":handlers",
+    ":deno_flatbuffer_builder",
     "//testing/gtest:gtest",
   ]
   configs += [ ":deno_config" ]
@@ -115,7 +104,6 @@ static_library("libdeno") {
   deps = [
     ":create_snapshot_deno",
     ":deno_bindings",
-    ":handlers",
   ]
   configs += [ ":deno_config" ]
 }
@@ -154,19 +142,29 @@ v8_source_set("deno_base_test") {
   configs = [ ":deno_config" ]
 }
 
-v8_source_set("deno_bindings") {
+v8_source_set("deno_flatbuffer_builder") {
   sources = [
     "src/flatbuffer_builder.cc",
     "src/flatbuffer_builder.h",
+  ]
+  deps = [
+    ":deno_base",
+  ]
+  public_deps = [
+    "build_extra/flatbuffers:flatbuffers",
+  ]
+  configs = [ ":deno_config" ]
+}
+
+v8_source_set("deno_bindings") {
+  sources = [
     "src/reply.cc",
     "src/reply.h",
   ]
   deps = [
     ":deno_base",
+    ":deno_flatbuffer_builder",
     ":msg_cpp",
-  ]
-  public_deps = [
-    "build_extra/flatbuffers:flatbuffers",
   ]
   configs = [ ":deno_config" ]
 }
@@ -232,7 +230,6 @@ source_set("libdeno_nosnapshot") {
   deps = [
     ":bundle",
     ":deno_bindings",
-    ":handlers",
   ]
   configs += [ ":deno_config" ]
   bundle_outputs = get_target_outputs(":bundle")
@@ -269,6 +266,12 @@ action("flatbufferjs") {
 }
 
 ts_flatbuffer("msg_ts") {
+  sources = [
+    "src/msg.fbs",
+  ]
+}
+
+rust_flatbuffer("msg_rs") {
   sources = [
     "src/msg.fbs",
   ]

--- a/build_extra/flatbuffers/rust/BUILD.gn
+++ b/build_extra/flatbuffers/rust/BUILD.gn
@@ -1,0 +1,5 @@
+import("//build_extra/rust/rust.gni")
+
+rust_component("flatbuffers") {
+  source_root = "//third_party/flatbuffers/rust/flatbuffers/src/lib.rs"
+}

--- a/build_extra/flatbuffers/rust/rust_flatbuffer.gni
+++ b/build_extra/flatbuffers/rust/rust_flatbuffer.gni
@@ -1,0 +1,44 @@
+import("//build_extra/rust/rust.gni")
+
+# TODO(ry) "flatbuffer.gni" should be "flatbuffers.gni" we should be consistant
+# in our pluralization.
+import("//build_extra/flatbuffers/flatbuffer.gni")
+
+template("rust_flatbuffer") {
+  action_name = "${target_name}_gen"
+  source_set_name = target_name
+  compiled_action_foreach(action_name) {
+    tool = "$flatbuffers_build_location:flatc"
+
+    sources = invoker.sources
+    deps = []
+    out_dir = target_gen_dir
+
+    outputs = [
+      "$out_dir/{{source_name_part}}_generated.rs",
+    ]
+
+    args = [
+      "--rust",
+      "-o",
+      rebase_path(out_dir, root_build_dir),
+      "-I",
+      rebase_path("//", root_build_dir),
+    ]
+    args += [ "{{source}}" ]
+
+    # The deps may have steps that have to run before running flatc.
+    if (defined(invoker.deps)) {
+      deps += invoker.deps
+    }
+  }
+
+  rust_component(source_set_name) {
+    sources = get_target_outputs(":$action_name")
+    source_root = sources[0]
+    deps = [
+      ":$action_name",
+    ]
+    extern = [ "//build_extra/flatbuffers/rust:flatbuffers" ]
+  }
+}

--- a/build_extra/rust/rust.gni
+++ b/build_extra/rust/rust.gni
@@ -163,6 +163,7 @@ template("rust_component") {
                              "is_test",
                              "testonly",
                              "args",
+                             "deps",
                            ])
     if (!defined(invoker.crate_type)) {
       crate_type = "rlib"

--- a/js/main.ts
+++ b/js/main.ts
@@ -16,10 +16,11 @@ function assignCmdId(): number {
 
 function startMsg(cmdId: number): Uint8Array {
   const builder = new flatbuffers.Builder();
-  const msg = fbs.Start.createStart(builder, 0);
+  fbs.Start.startStart(builder);
+  const startOffset = fbs.Start.endStart(builder);
   fbs.Base.startBase(builder);
   fbs.Base.addCmdId(builder, cmdId);
-  fbs.Base.addMsg(builder, msg);
+  fbs.Base.addMsg(builder, startOffset);
   fbs.Base.addMsgType(builder, fbs.Any.Start);
   builder.finish(fbs.Base.endBase(builder));
   return builder.asUint8Array();

--- a/js/mock_runtime.js
+++ b/js/mock_runtime.js
@@ -31,9 +31,8 @@ global.SendSuccess = () => {
   });
 };
 
-global.SendByteLength = () => {
+global.SendWrongByteLength = () => {
   deno.recv(msg => {
-    assert(msg instanceof ArrayBuffer);
     assert(msg.byteLength === 3);
   });
 };

--- a/js/mock_runtime.js
+++ b/js/mock_runtime.js
@@ -134,3 +134,14 @@ global.ErrorHandling = () => {
   };
   eval("\n\n notdefined()\n//# sourceURL=helloworld.js");
 };
+
+global.SendNullAllocPtr = () => {
+  deno.recv(msg => {
+    assert(msg instanceof Uint8Array);
+    assert(msg.byteLength === 4);
+    assert(msg[0] === "a".charCodeAt(0));
+    assert(msg[1] === "b".charCodeAt(0));
+    assert(msg[2] === "c".charCodeAt(0));
+    assert(msg[3] === "d".charCodeAt(0));
+  });
+};

--- a/js/msg_generated.ts
+++ b/js/msg_generated.ts
@@ -198,10 +198,20 @@ __init(i:number, bb:flatbuffers.ByteBuffer):Start {
 };
 
 /**
+ * @param {flatbuffers.ByteBuffer} bb
+ * @param {Start=} obj
+ * @returns {Start}
+ */
+static getRootAsStart(bb:flatbuffers.ByteBuffer, obj?:Start):Start {
+  return (obj || new Start).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+};
+
+/**
  * @returns {number}
  */
 unused():number {
-  return this.bb!.readInt8(this.bb_pos);
+  var offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.readInt8(this.bb_pos + offset) : 0;
 };
 
 /**
@@ -209,7 +219,7 @@ unused():number {
  * @returns {boolean}
  */
 mutate_unused(value:number):boolean {
-  var offset = this.bb!.__offset(this.bb_pos, 0);
+  var offset = this.bb!.__offset(this.bb_pos, 4);
 
   if (offset === 0) {
     return false;
@@ -221,13 +231,26 @@ mutate_unused(value:number):boolean {
 
 /**
  * @param {flatbuffers.Builder} builder
+ */
+static startStart(builder:flatbuffers.Builder) {
+  builder.startObject(1);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @param {number} unused
+ */
+static addUnused(builder:flatbuffers.Builder, unused:number) {
+  builder.addFieldInt8(0, unused, 0);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @returns {flatbuffers.Offset}
  */
-static createStart(builder:flatbuffers.Builder, unused: number):flatbuffers.Offset {
-  builder.prep(1, 1);
-  builder.writeInt8(unused);
-  return builder.offset();
+static endStart(builder:flatbuffers.Builder):flatbuffers.Offset {
+  var offset = builder.endObject();
+  return offset;
 };
 
 }
@@ -736,10 +759,20 @@ __init(i:number, bb:flatbuffers.ByteBuffer):Exit {
 };
 
 /**
+ * @param {flatbuffers.ByteBuffer} bb
+ * @param {Exit=} obj
+ * @returns {Exit}
+ */
+static getRootAsExit(bb:flatbuffers.ByteBuffer, obj?:Exit):Exit {
+  return (obj || new Exit).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+};
+
+/**
  * @returns {number}
  */
 code():number {
-  return this.bb!.readInt32(this.bb_pos);
+  var offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.readInt32(this.bb_pos + offset) : 0;
 };
 
 /**
@@ -747,7 +780,7 @@ code():number {
  * @returns {boolean}
  */
 mutate_code(value:number):boolean {
-  var offset = this.bb!.__offset(this.bb_pos, 0);
+  var offset = this.bb!.__offset(this.bb_pos, 4);
 
   if (offset === 0) {
     return false;
@@ -759,13 +792,26 @@ mutate_code(value:number):boolean {
 
 /**
  * @param {flatbuffers.Builder} builder
+ */
+static startExit(builder:flatbuffers.Builder) {
+  builder.startObject(1);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @param {number} code
+ */
+static addCode(builder:flatbuffers.Builder, code:number) {
+  builder.addFieldInt32(0, code, 0);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @returns {flatbuffers.Offset}
  */
-static createExit(builder:flatbuffers.Builder, code: number):flatbuffers.Offset {
-  builder.prep(4, 4);
-  builder.writeInt32(code);
-  return builder.offset();
+static endExit(builder:flatbuffers.Builder):flatbuffers.Offset {
+  var offset = builder.endObject();
+  return offset;
 };
 
 }
@@ -796,10 +842,20 @@ __init(i:number, bb:flatbuffers.ByteBuffer):TimerStart {
 };
 
 /**
+ * @param {flatbuffers.ByteBuffer} bb
+ * @param {TimerStart=} obj
+ * @returns {TimerStart}
+ */
+static getRootAsTimerStart(bb:flatbuffers.ByteBuffer, obj?:TimerStart):TimerStart {
+  return (obj || new TimerStart).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+};
+
+/**
  * @returns {number}
  */
 id():number {
-  return this.bb!.readUint32(this.bb_pos);
+  var offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.readUint32(this.bb_pos + offset) : 0;
 };
 
 /**
@@ -807,7 +863,7 @@ id():number {
  * @returns {boolean}
  */
 mutate_id(value:number):boolean {
-  var offset = this.bb!.__offset(this.bb_pos, 0);
+  var offset = this.bb!.__offset(this.bb_pos, 4);
 
   if (offset === 0) {
     return false;
@@ -821,7 +877,8 @@ mutate_id(value:number):boolean {
  * @returns {boolean}
  */
 interval():boolean {
-  return !!this.bb!.readInt8(this.bb_pos + 4);
+  var offset = this.bb!.__offset(this.bb_pos, 6);
+  return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
 };
 
 /**
@@ -829,7 +886,7 @@ interval():boolean {
  * @returns {boolean}
  */
 mutate_interval(value:boolean):boolean {
-  var offset = this.bb!.__offset(this.bb_pos, 4);
+  var offset = this.bb!.__offset(this.bb_pos, 6);
 
   if (offset === 0) {
     return false;
@@ -843,7 +900,8 @@ mutate_interval(value:boolean):boolean {
  * @returns {number}
  */
 delay():number {
-  return this.bb!.readInt32(this.bb_pos + 8);
+  var offset = this.bb!.__offset(this.bb_pos, 8);
+  return offset ? this.bb!.readInt32(this.bb_pos + offset) : 0;
 };
 
 /**
@@ -863,18 +921,42 @@ mutate_delay(value:number):boolean {
 
 /**
  * @param {flatbuffers.Builder} builder
+ */
+static startTimerStart(builder:flatbuffers.Builder) {
+  builder.startObject(3);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @param {number} id
+ */
+static addId(builder:flatbuffers.Builder, id:number) {
+  builder.addFieldInt32(0, id, 0);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @param {boolean} interval
+ */
+static addInterval(builder:flatbuffers.Builder, interval:boolean) {
+  builder.addFieldInt8(1, +interval, +false);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @param {number} delay
+ */
+static addDelay(builder:flatbuffers.Builder, delay:number) {
+  builder.addFieldInt32(2, delay, 0);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @returns {flatbuffers.Offset}
  */
-static createTimerStart(builder:flatbuffers.Builder, id: number, interval: boolean, delay: number):flatbuffers.Offset {
-  builder.prep(4, 12);
-  builder.writeInt32(delay);
-  builder.pad(3);
-  builder.writeInt8(+interval);
-  builder.writeInt32(id);
-  return builder.offset();
+static endTimerStart(builder:flatbuffers.Builder):flatbuffers.Offset {
+  var offset = builder.endObject();
+  return offset;
 };
 
 }
@@ -905,10 +987,20 @@ __init(i:number, bb:flatbuffers.ByteBuffer):TimerReady {
 };
 
 /**
+ * @param {flatbuffers.ByteBuffer} bb
+ * @param {TimerReady=} obj
+ * @returns {TimerReady}
+ */
+static getRootAsTimerReady(bb:flatbuffers.ByteBuffer, obj?:TimerReady):TimerReady {
+  return (obj || new TimerReady).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+};
+
+/**
  * @returns {number}
  */
 id():number {
-  return this.bb!.readUint32(this.bb_pos);
+  var offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.readUint32(this.bb_pos + offset) : 0;
 };
 
 /**
@@ -916,7 +1008,7 @@ id():number {
  * @returns {boolean}
  */
 mutate_id(value:number):boolean {
-  var offset = this.bb!.__offset(this.bb_pos, 0);
+  var offset = this.bb!.__offset(this.bb_pos, 4);
 
   if (offset === 0) {
     return false;
@@ -930,7 +1022,8 @@ mutate_id(value:number):boolean {
  * @returns {boolean}
  */
 done():boolean {
-  return !!this.bb!.readInt8(this.bb_pos + 4);
+  var offset = this.bb!.__offset(this.bb_pos, 6);
+  return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
 };
 
 /**
@@ -938,7 +1031,7 @@ done():boolean {
  * @returns {boolean}
  */
 mutate_done(value:boolean):boolean {
-  var offset = this.bb!.__offset(this.bb_pos, 4);
+  var offset = this.bb!.__offset(this.bb_pos, 6);
 
   if (offset === 0) {
     return false;
@@ -950,16 +1043,34 @@ mutate_done(value:boolean):boolean {
 
 /**
  * @param {flatbuffers.Builder} builder
+ */
+static startTimerReady(builder:flatbuffers.Builder) {
+  builder.startObject(2);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @param {number} id
+ */
+static addId(builder:flatbuffers.Builder, id:number) {
+  builder.addFieldInt32(0, id, 0);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @param {boolean} done
+ */
+static addDone(builder:flatbuffers.Builder, done:boolean) {
+  builder.addFieldInt8(1, +done, +false);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @returns {flatbuffers.Offset}
  */
-static createTimerReady(builder:flatbuffers.Builder, id: number, done: boolean):flatbuffers.Offset {
-  builder.prep(4, 8);
-  builder.pad(3);
-  builder.writeInt8(+done);
-  builder.writeInt32(id);
-  return builder.offset();
+static endTimerReady(builder:flatbuffers.Builder):flatbuffers.Offset {
+  var offset = builder.endObject();
+  return offset;
 };
 
 }
@@ -990,10 +1101,20 @@ __init(i:number, bb:flatbuffers.ByteBuffer):TimerClear {
 };
 
 /**
+ * @param {flatbuffers.ByteBuffer} bb
+ * @param {TimerClear=} obj
+ * @returns {TimerClear}
+ */
+static getRootAsTimerClear(bb:flatbuffers.ByteBuffer, obj?:TimerClear):TimerClear {
+  return (obj || new TimerClear).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+};
+
+/**
  * @returns {number}
  */
 id():number {
-  return this.bb!.readUint32(this.bb_pos);
+  var offset = this.bb!.__offset(this.bb_pos, 4);
+  return offset ? this.bb!.readUint32(this.bb_pos + offset) : 0;
 };
 
 /**
@@ -1001,7 +1122,7 @@ id():number {
  * @returns {boolean}
  */
 mutate_id(value:number):boolean {
-  var offset = this.bb!.__offset(this.bb_pos, 0);
+  var offset = this.bb!.__offset(this.bb_pos, 4);
 
   if (offset === 0) {
     return false;
@@ -1013,13 +1134,26 @@ mutate_id(value:number):boolean {
 
 /**
  * @param {flatbuffers.Builder} builder
+ */
+static startTimerClear(builder:flatbuffers.Builder) {
+  builder.startObject(1);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @param {number} id
+ */
+static addId(builder:flatbuffers.Builder, id:number) {
+  builder.addFieldInt32(0, id, 0);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @returns {flatbuffers.Offset}
  */
-static createTimerClear(builder:flatbuffers.Builder, id: number):flatbuffers.Offset {
-  builder.prep(4, 4);
-  builder.writeInt32(id);
-  return builder.offset();
+static endTimerClear(builder:flatbuffers.Builder):flatbuffers.Offset {
+  var offset = builder.endObject();
+  return offset;
 };
 
 }

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -1,11 +1,9 @@
 // Copyright 2018 the Deno authors. All rights reserved. MIT license.
 #![allow(dead_code)]
-
 extern crate libc;
 use libc::c_char;
 use libc::c_int;
 use libc::c_void;
-use libc::uint32_t;
 
 #[repr(C)]
 pub struct DenoC {
@@ -14,10 +12,10 @@ pub struct DenoC {
 
 #[repr(C)]
 pub struct deno_buf {
-  alloc_ptr: *mut u8,
-  alloc_len: usize,
-  data_ptr: *mut u8,
-  data_len: usize,
+  pub alloc_ptr: *mut u8,
+  pub alloc_len: usize,
+  pub data_ptr: *mut u8,
+  pub data_len: usize,
 }
 
 type DenoRecvCb = unsafe extern "C" fn(d: *const DenoC, buf: deno_buf);
@@ -36,18 +34,4 @@ extern "C" {
     js_source: *const c_char,
   ) -> c_int;
   pub fn deno_handle_msg_from_js(d: *const DenoC, buf: deno_buf);
-  pub fn deno_reply_error(
-    d: *const DenoC,
-    cmd_id: uint32_t,
-    msg: *const c_char,
-  );
-  pub fn deno_reply_null(d: *const DenoC, cmd_id: uint32_t);
-  pub fn deno_reply_code_fetch(
-    d: *const DenoC,
-    cmd_id: uint32_t,
-    module_name: *const c_char,
-    filename: *const c_char,
-    source_code: *const c_char,
-    output_code: *const c_char,
-  );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,17 @@
 extern crate libc;
 #[macro_use]
 extern crate log;
+extern crate flatbuffers;
+extern crate msg_rs as msg_generated;
+extern crate url;
 
 use libc::c_int;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::ptr;
 
+mod handlers;
+pub use handlers::*;
 mod binding;
 use binding::{
   deno_delete, deno_execute, deno_handle_msg_from_js, deno_init,

--- a/src/mock_runtime_test.cc
+++ b/src/mock_runtime_test.cc
@@ -41,11 +41,14 @@ TEST(MockRuntimeTest, SendSuccess) {
   deno_delete(d);
 }
 
-TEST(MockRuntimeTest, SendByteLength) {
+TEST(MockRuntimeTest, SendWrongByteLength) {
   Deno* d = deno_new(nullptr, nullptr);
-  EXPECT_TRUE(deno_execute(d, "a.js", "SendByteLength()"));
-  // We pub the wrong sized message, it should throw.
+  EXPECT_TRUE(deno_execute(d, "a.js", "SendWrongByteLength()"));
+  // deno_send the wrong sized message, it should throw.
   EXPECT_FALSE(deno_send(d, strbuf("abcd")));
+  std::string exception = deno_last_exception(d);
+  EXPECT_GT(exception.length(), 1);
+  EXPECT_NE(exception.find("assert"), std::string::npos);
   deno_delete(d);
 }
 

--- a/src/msg.fbs
+++ b/src/msg.fbs
@@ -23,7 +23,7 @@ table Base {
   msg: Any;
 }
 
-struct Start {
+table Start {
   unused: int8;
 }
 
@@ -54,22 +54,22 @@ table CodeCache {
   output_code: string;
 }
 
-struct Exit {
+table Exit {
   code: int;
 }
 
-struct TimerStart {
+table TimerStart {
   id: uint;
   interval: bool;
   delay: int;
 }
 
-struct TimerReady {
+table TimerReady {
   id: uint;
   done: bool;
 }
 
-struct TimerClear {
+table TimerClear {
   id: uint;
 }
 

--- a/src/reply.cc
+++ b/src/reply.cc
@@ -21,35 +21,6 @@
 
 extern "C" {
 
-void deno_reply_error(Deno* d, uint32_t cmd_id, const char* error_msg) {
-  // printf("deno_reply_error: %s\n", error_msg);
-  deno::FlatBufferBuilder builder;
-  auto error_msg_ = error_msg ? builder.CreateString(error_msg) : 0;
-  auto base = deno::CreateBase(builder, cmd_id, error_msg_);
-  builder.Finish(base);
-  deno_set_response(d, builder.ExportBuf());
-}
-
-void deno_reply_null(Deno* d, uint32_t cmd_id) {
-  deno_reply_error(d, cmd_id, nullptr);
-}
-
-void deno_reply_code_fetch(Deno* d, uint32_t cmd_id, const char* module_name,
-                           const char* filename, const char* source_code,
-                           const char* output_code) {
-  deno::FlatBufferBuilder builder;
-  auto module_name_ = builder.CreateString(module_name);
-  auto filename_ = builder.CreateString(filename);
-  auto source_code_ = builder.CreateString(source_code);
-  auto output_code_ = builder.CreateString(output_code);
-  auto code_fetch_res = deno::CreateCodeFetchRes(
-      builder, module_name_, filename_, source_code_, output_code_);
-  auto base = deno::CreateBase(builder, cmd_id, 0, deno::Any_CodeFetchRes,
-                               code_fetch_res.Union());
-  builder.Finish(base);
-  deno_set_response(d, builder.ExportBuf());
-}
-
 void deno_reply_start(Deno* d, uint32_t cmd_id, int argc, char* argv[],
                       char* cwd) {
   deno::FlatBufferBuilder builder;

--- a/src/reply.h
+++ b/src/reply.h
@@ -12,16 +12,6 @@
 #include "deno.h"
 
 extern "C" {
-
-void deno_reply_null(Deno* d, uint32_t cmd_id);
-void deno_reply_error(Deno* d, uint32_t cmd_id, const char* error_msg);
-
-void deno_reply_start(Deno* d, uint32_t cmd_id, int argc, char* argv[],
-                      char* cwd);
-void deno_reply_code_fetch(Deno* d, uint32_t cmd_id, const char* module_name,
-                           const char* filename, const char* source_code,
-                           const char* output_code);
-
 // Parse incoming messages with C++ Flatbuffers, call into rust handlers.
 void deno_handle_msg_from_js(Deno* d, deno_buf buf);
 }

--- a/tools/format.py
+++ b/tools/format.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
-
 import os
-from glob import glob
-from util import run
+from util import run, find_exts
 
 root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 third_party_path = os.path.join(root_path, "third_party")
@@ -12,15 +10,19 @@ tools_path = os.path.join(root_path, "tools")
 rustfmt_config = os.path.join(tools_path, "rustfmt.toml")
 
 os.chdir(root_path)
-# TODO(ry) Install clang-format in third_party.
-run(["clang-format", "-i", "-style", "Google"] + glob("src/*.cc") +
-    glob("src/*.h"))
-for fn in ["BUILD.gn", ".gn"] + glob("build_extra/**/*.gn*"):
-    run(["gn", "format", fn])
+
+# TODO(ry) Use third_party/depot_tools/clang-format.
+run(["clang-format", "-i", "-style", "Google"] + find_exts("src", ".cc", ".h"))
+
+for fn in ["BUILD.gn", ".gn"] + find_exts("build_extra", ".gn", ".gni"):
+    run(["third_party/depot_tools/gn", "format", fn])
+
 # TODO(ry) Install yapf in third_party.
-run(["yapf", "-i"] + glob("tools/*.py") + glob("build_extra/**/*.py"))
-run(["node", prettier, "--write"] + glob("js/*.js") + glob("js/*.ts") +
-    ["tsconfig.json"] + ["tslint.json"])
+run(["yapf", "-i"] + find_exts("tools/", ".py") +
+    find_exts("build_extra", ".py"))
+
+run(["node", prettier, "--write"] + find_exts("js/", ".js", ".ts") +
+    ["tsconfig.json", "tslint.json"])
 
 # Set RUSTFMT_FLAGS for extra flags.
 rustfmt_extra_args = []
@@ -29,4 +31,4 @@ if 'RUSTFMT_FLAGS' in os.environ:
 run([
     "rustfmt", "--config-path", rustfmt_config, "--error-on-unformatted",
     "--write-mode", "overwrite"
-] + rustfmt_extra_args + glob("src/*.rs"))
+] + rustfmt_extra_args + find_exts("src/", ".rs"))

--- a/tools/test.py
+++ b/tools/test.py
@@ -24,9 +24,9 @@ def main(argv):
     check_exists(test_cc)
     run([test_cc])
 
-    handlers_test = os.path.join(build_dir, "handlers_test" + executable_suffix)
-    check_exists(handlers_test)
-    run([handlers_test])
+    test_rs = os.path.join(build_dir, "test_rs" + executable_suffix)
+    check_exists(test_rs)
+    run([test_rs])
 
     deno_exe = os.path.join(build_dir, "deno" + executable_suffix)
     check_exists(deno_exe)

--- a/tools/util.py
+++ b/tools/util.py
@@ -55,3 +55,16 @@ def touch(fname):
         os.utime(fname, None)
     else:
         open(fname, 'a').close()
+
+
+# Recursive search for files of certain extensions.
+# (Recursive glob doesn't exist in python 2.7.)
+def find_exts(directory, *extensions):
+    matches = []
+    for root, dirnames, filenames in os.walk(directory):
+        for filename in filenames:
+            for ext in extensions:
+                if filename.endswith(ext):
+                    matches.append(os.path.join(root, filename))
+                    break
+    return matches


### PR DESCRIPTION
- Add build scripts for Rust flatbuffers.
- Rewrites some reply.cc methods in Rust.
- Changes some struct elements to table in msg.fbs (rust flatbuffers
  lacks support currently)
- Renames handlers_test to test_rs.
- This reorg is needed to make progress on the code cache handler.
