### PR TITLE
Update to TypeScript 3.0.1

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
 js/flatbuffers.js
-js/lib.deno.d.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 js/flatbuffers.js
+js/lib.deno.d.ts

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -193,6 +193,7 @@ run_node("bundle") {
     "js/deno.d.ts",
     "js/dispatch.ts",
     "js/globals.ts",
+    "js/lib.deno.d.ts",
     "js/main.ts",
     "js/os.ts",
     "js/runtime.ts",

--- a/js/assets.ts
+++ b/js/assets.ts
@@ -6,9 +6,11 @@
 // There is a rollup plugin that will inline any module ending with `!string`
 // tslint:disable:max-line-length
 import denoDts from "/js/deno.d.ts!string";
-import libDts from "/third_party/node_modules/typescript/lib/lib.d.ts!string";
-import libDom from "/third_party/node_modules/typescript/lib/lib.dom.d.ts!string";
-import libDomIterableDts from "/third_party/node_modules/typescript/lib/lib.dom.iterable.d.ts!string";
+// import libDts from "/third_party/node_modules/typescript/lib/lib.d.ts!string";
+import libDenoDts from "/js/lib.deno.d.ts!string";
+// import libDomD qts from "/third_party/node_modules/typescript/lib/lib.dom.d.ts!string";
+// import libDomIterableDts from "/third_party/node_modules/typescript/lib/lib.dom.iterable.d.ts!string";
+import libEs2015Dts from "/third_party/node_modules/typescript/lib/lib.es2015.d.ts!string";
 import libEs2015CollectionDts from "/third_party/node_modules/typescript/lib/lib.es2015.collection.d.ts!string";
 import libEs2015CoreDts from "/third_party/node_modules/typescript/lib/lib.es2015.core.d.ts!string";
 import libEs2015GeneratorDts from "/third_party/node_modules/typescript/lib/lib.es2015.generator.d.ts!string";
@@ -18,32 +20,38 @@ import libEs2015ProxyDts from "/third_party/node_modules/typescript/lib/lib.es20
 import libEs2015ReflectDts from "/third_party/node_modules/typescript/lib/lib.es2015.reflect.d.ts!string";
 import libEs2015SymbolDts from "/third_party/node_modules/typescript/lib/lib.es2015.symbol.d.ts!string";
 import libEs2015SymbolWellknownDts from "/third_party/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts!string";
+import libEs2016Dts from "/third_party/node_modules/typescript/lib/lib.es2016.d.ts!string";
 import libEs2016ArrayIncludeDts from "/third_party/node_modules/typescript/lib/lib.es2016.array.include.d.ts!string";
+import libEs2017Dts from "/third_party/node_modules/typescript/lib/lib.es2017.d.ts!string";
 import libEs2017IntlDts from "/third_party/node_modules/typescript/lib/lib.es2017.intl.d.ts!string";
 import libEs2017ObjectDts from "/third_party/node_modules/typescript/lib/lib.es2017.object.d.ts!string";
 import libEs2017SharedmemoryDts from "/third_party/node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts!string";
 import libEs2017StringDts from "/third_party/node_modules/typescript/lib/lib.es2017.string.d.ts!string";
 import libEs2017TypedarraysDts from "/third_party/node_modules/typescript/lib/lib.es2017.typedarrays.d.ts!string";
 import libEs2018Dts from "/third_party/node_modules/typescript/lib/lib.es2018.d.ts!string";
+import libEs2018IntlDts from "/third_party/node_modules/typescript/lib/lib.es2018.intl.d.ts!string";
 import libEs2018PromiseDts from "/third_party/node_modules/typescript/lib/lib.es2018.promise.d.ts!string";
 import libEs2018RegexpDts from "/third_party/node_modules/typescript/lib/lib.es2018.regexp.d.ts!string";
-import libEs5 from "/third_party/node_modules/typescript/lib/lib.es5.d.ts!string";
+import libEs5Dts from "/third_party/node_modules/typescript/lib/lib.es5.d.ts!string";
 import libEsnextArrayDts from "/third_party/node_modules/typescript/lib/lib.esnext.array.d.ts!string";
 import libEsnextAsynciterablesDts from "/third_party/node_modules/typescript/lib/lib.esnext.asynciterable.d.ts!string";
 import libEsnextDts from "/third_party/node_modules/typescript/lib/lib.esnext.d.ts!string";
-import libScripthost from "/third_party/node_modules/typescript/lib/lib.scripthost.d.ts!string";
-import libWebworkerImportscripts from "/third_party/node_modules/typescript/lib/lib.webworker.importscripts.d.ts!string";
+import libEsnextIntlDts from "/third_party/node_modules/typescript/lib/lib.esnext.intl.d.ts!string";
+import libEsnextSymbolDts from "/third_party/node_modules/typescript/lib/lib.esnext.symbol.d.ts!string";
+// import libScripthost from "/third_party/node_modules/typescript/lib/lib.scripthost.d.ts!string";
+// import libWebworkerImportscripts from "/third_party/node_modules/typescript/lib/lib.webworker.importscripts.d.ts!string";
 import typescriptDts from "/third_party/node_modules/typescript/lib/typescript.d.ts!string";
 
 // prettier-ignore
 export const assetSourceCode: { [key: string]: string } = {
   "deno.d.ts": denoDts,
-  "lib.d.ts": libDts,
-  "lib.dom.d.ts": libDom,
-  "lib.dom.iterable.d.ts": libDomIterableDts,
+  // "lib.d.ts": libDts,
+  "lib.deno.d.ts": libDenoDts,
+  // "lib.dom.d.ts": libDomDts,
+  // "lib.dom.iterable.d.ts": libDomIterableDts,
   "lib.es2015.collection.d.ts": libEs2015CollectionDts,
   "lib.es2015.core.d.ts": libEs2015CoreDts,
-  //"lib.es2015.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.es2015.d.ts", "utf8"),
+  "lib.es2015.d.ts": libEs2015Dts,
   "lib.es2015.generator.d.ts": libEs2015GeneratorDts,
   "lib.es2015.iterable.d.ts": libEs2015IterableDts,
   "lib.es2015.promise.d.ts": libEs2015PromiseDts,
@@ -52,9 +60,9 @@ export const assetSourceCode: { [key: string]: string } = {
   "lib.es2015.symbol.d.ts": libEs2015SymbolDts,
   "lib.es2015.symbol.wellknown.d.ts": libEs2015SymbolWellknownDts,
   "lib.es2016.array.include.d.ts": libEs2016ArrayIncludeDts,
-  //"lib.es2016.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.es2016.d.ts", "utf8"),
+  "lib.es2016.d.ts": libEs2016Dts,
   //"lib.es2016.full.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.es2016.full.d.ts", "utf8"),
-  //"lib.es2017.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.es2017.d.ts", "utf8"),
+  "lib.es2017.d.ts": libEs2017Dts,
   //"lib.es2017.full.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.es2017.full.d.ts", "utf8"),
   "lib.es2017.intl.d.ts": libEs2017IntlDts,
   "lib.es2017.object.d.ts": libEs2017ObjectDts,
@@ -63,17 +71,20 @@ export const assetSourceCode: { [key: string]: string } = {
   "lib.es2017.typedarrays.d.ts": libEs2017TypedarraysDts,
   "lib.es2018.d.ts": libEs2018Dts,
   //"lib.es2018.full.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.es2018.full.d.ts", "utf8"),
+  "lib.es2018.intl.d.ts": libEs2018IntlDts,
   "lib.es2018.promise.d.ts": libEs2018PromiseDts,
   "lib.es2018.regexp.d.ts": libEs2018RegexpDts,
-  "lib.es5.d.ts": libEs5,
+  "lib.es5.d.ts": libEs5Dts,
   //"lib.es6.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.es6.d.ts", "utf8"),
+  "lib.esnext.d.ts": libEsnextDts,
   "lib.esnext.array.d.ts": libEsnextArrayDts,
   "lib.esnext.asynciterable.d.ts": libEsnextAsynciterablesDts,
-  "lib.esnext.d.ts": libEsnextDts,
+  "lib.esnext.intl.d.ts": libEsnextIntlDts,
+  "lib.esnext.symbol.d.ts": libEsnextSymbolDts,
   //"lib.esnext.full.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.esnext.full.d.ts", "utf8"),
-  "lib.scripthost.d.ts": libScripthost,
+  // "lib.scripthost.d.ts": libScripthost,
   // "lib.webworker.d.ts": libWebworker,
-  "lib.webworker.importscripts.d.ts": libWebworkerImportscripts,
+  // "lib.webworker.importscripts.d.ts": libWebworkerImportscripts,
   //"protocol.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/protocol.d.ts", "utf8"),
   //"tsserverlibrary.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/tsserverlibrary.d.ts", "utf8"),
   "typescript.d.ts": typescriptDts,

--- a/js/assets.ts
+++ b/js/assets.ts
@@ -7,6 +7,7 @@
 // tslint:disable:max-line-length
 import denoDts from "/js/deno.d.ts!string";
 import libDts from "/third_party/node_modules/typescript/lib/lib.d.ts!string";
+import libDom from "/third_party/node_modules/typescript/lib/lib.dom.d.ts!string";
 import libDomIterableDts from "/third_party/node_modules/typescript/lib/lib.dom.iterable.d.ts!string";
 import libEs2015CollectionDts from "/third_party/node_modules/typescript/lib/lib.es2015.collection.d.ts!string";
 import libEs2015CoreDts from "/third_party/node_modules/typescript/lib/lib.es2015.core.d.ts!string";
@@ -26,16 +27,19 @@ import libEs2017TypedarraysDts from "/third_party/node_modules/typescript/lib/li
 import libEs2018Dts from "/third_party/node_modules/typescript/lib/lib.es2018.d.ts!string";
 import libEs2018PromiseDts from "/third_party/node_modules/typescript/lib/lib.es2018.promise.d.ts!string";
 import libEs2018RegexpDts from "/third_party/node_modules/typescript/lib/lib.es2018.regexp.d.ts!string";
+import libEs5 from "/third_party/node_modules/typescript/lib/lib.es5.d.ts!string";
 import libEsnextArrayDts from "/third_party/node_modules/typescript/lib/lib.esnext.array.d.ts!string";
 import libEsnextAsynciterablesDts from "/third_party/node_modules/typescript/lib/lib.esnext.asynciterable.d.ts!string";
 import libEsnextDts from "/third_party/node_modules/typescript/lib/lib.esnext.d.ts!string";
+import libScripthost from "/third_party/node_modules/typescript/lib/lib.scripthost.d.ts!string";
+import libWebworkerImportscripts from "/third_party/node_modules/typescript/lib/lib.webworker.importscripts.d.ts!string";
 import typescriptDts from "/third_party/node_modules/typescript/lib/typescript.d.ts!string";
 
 // prettier-ignore
 export const assetSourceCode: { [key: string]: string } = {
   "deno.d.ts": denoDts,
   "lib.d.ts": libDts,
-  //"lib.dom.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.dom.d.ts", "utf8"),
+  "lib.dom.d.ts": libDom,
   "lib.dom.iterable.d.ts": libDomIterableDts,
   "lib.es2015.collection.d.ts": libEs2015CollectionDts,
   "lib.es2015.core.d.ts": libEs2015CoreDts,
@@ -61,14 +65,15 @@ export const assetSourceCode: { [key: string]: string } = {
   //"lib.es2018.full.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.es2018.full.d.ts", "utf8"),
   "lib.es2018.promise.d.ts": libEs2018PromiseDts,
   "lib.es2018.regexp.d.ts": libEs2018RegexpDts,
-  //"lib.es5.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.es5.d.ts", "utf8"),
+  "lib.es5.d.ts": libEs5,
   //"lib.es6.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.es6.d.ts", "utf8"),
   "lib.esnext.array.d.ts": libEsnextArrayDts,
   "lib.esnext.asynciterable.d.ts": libEsnextAsynciterablesDts,
   "lib.esnext.d.ts": libEsnextDts,
   //"lib.esnext.full.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.esnext.full.d.ts", "utf8"),
-  //"lib.scripthost.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.scripthost.d.ts", "utf8"),
-  //"lib.webworker.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/lib.webworker.d.ts", "utf8"),
+  "lib.scripthost.d.ts": libScripthost,
+  // "lib.webworker.d.ts": libWebworker,
+  "lib.webworker.importscripts.d.ts": libWebworkerImportscripts,
   //"protocol.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/protocol.d.ts", "utf8"),
   //"tsserverlibrary.d.ts": readFileSync(__dirname + "/../third_party/node_modules/typescript/lib/tsserverlibrary.d.ts", "utf8"),
   "typescript.d.ts": typescriptDts,

--- a/js/lib.deno.d.ts
+++ b/js/lib.deno.d.ts
@@ -6,41 +6,25 @@
 
 /// <reference lib="esnext" />
 
-// This needs to be stripped down to what is supported by V8 without a DOM
-interface Console {
-  memory: any;
-  assert(condition?: boolean, message?: string, ...data: any[]): void;
-  clear(): void;
-  count(label?: string): void;
-  debug(message?: any, ...optionalParams: any[]): void;
-  dir(value?: any, ...optionalParams: any[]): void;
-  dirxml(value: any): void;
-  error(message?: any, ...optionalParams: any[]): void;
-  exception(message?: string, ...optionalParams: any[]): void;
-  group(groupTitle?: string, ...optionalParams: any[]): void;
-  groupCollapsed(groupTitle?: string, ...optionalParams: any[]): void;
-  groupEnd(): void;
-  info(message?: any, ...optionalParams: any[]): void;
-  log(message?: any, ...optionalParams: any[]): void;
-  markTimeline(label?: string): void;
-  // msIsIndependentlyComposed(element: Element): boolean;
-  profile(reportName?: string): void;
-  profileEnd(): void;
-  // select(element: Element): void;
-  table(...tabularData: any[]): void;
-  time(label?: string): void;
-  timeEnd(label?: string): void;
-  timeStamp(label?: string): void;
-  timeline(label?: string): void;
-  timelineEnd(label?: string): void;
-  trace(message?: any, ...optionalParams: any[]): void;
-  warn(message?: any, ...optionalParams: any[]): void;
-}
+// TODO generate `console.d.ts` and inline it in `assets.ts` and remove
+// declaration of `Console`
 
-declare var Console: {
-    prototype: Console;
-    new(): Console;
-};
+//import { Console } from 'gen/console';
+
+declare class Console {
+  // tslint:disable-next-line:no-any
+  log(...args: any[]): void;
+  // tslint:disable-next-line:no-any
+  debug(...args: any[]): void;
+  // tslint:disable-next-line:no-any
+  info(...args: any[]): void;
+  // tslint:disable-next-line:no-any
+  warn(...args: any[]): void;
+  // tslint:disable-next-line:no-any
+  error(...args: any[]): void;
+  // tslint:disable-next-line:no-any
+  assert(condition: boolean, ...args: any[]): void
+}
 
 interface Window {
   console: Console;

--- a/js/lib.deno.d.ts
+++ b/js/lib.deno.d.ts
@@ -23,7 +23,7 @@ declare class Console {
   // tslint:disable-next-line:no-any
   error(...args: any[]): void;
   // tslint:disable-next-line:no-any
-  assert(condition: boolean, ...args: any[]): void
+  assert(condition: boolean, ...args: any[]): void;
 }
 
 interface Window {

--- a/js/lib.deno.d.ts
+++ b/js/lib.deno.d.ts
@@ -1,0 +1,51 @@
+// Copyright 2018 the Deno authors. All rights reserved. MIT license.
+
+// This file contains the default TypeScript libraries for the runtime
+
+/// <reference no-default-lib="true"/>
+
+/// <reference lib="esnext" />
+
+// This needs to be stripped down to what is supported by V8 without a DOM
+interface Console {
+  memory: any;
+  assert(condition?: boolean, message?: string, ...data: any[]): void;
+  clear(): void;
+  count(label?: string): void;
+  debug(message?: any, ...optionalParams: any[]): void;
+  dir(value?: any, ...optionalParams: any[]): void;
+  dirxml(value: any): void;
+  error(message?: any, ...optionalParams: any[]): void;
+  exception(message?: string, ...optionalParams: any[]): void;
+  group(groupTitle?: string, ...optionalParams: any[]): void;
+  groupCollapsed(groupTitle?: string, ...optionalParams: any[]): void;
+  groupEnd(): void;
+  info(message?: any, ...optionalParams: any[]): void;
+  log(message?: any, ...optionalParams: any[]): void;
+  markTimeline(label?: string): void;
+  // msIsIndependentlyComposed(element: Element): boolean;
+  profile(reportName?: string): void;
+  profileEnd(): void;
+  // select(element: Element): void;
+  table(...tabularData: any[]): void;
+  time(label?: string): void;
+  timeEnd(label?: string): void;
+  timeStamp(label?: string): void;
+  timeline(label?: string): void;
+  timelineEnd(label?: string): void;
+  trace(message?: any, ...optionalParams: any[]): void;
+  warn(message?: any, ...optionalParams: any[]): void;
+}
+
+declare var Console: {
+    prototype: Console;
+    new(): Console;
+};
+
+interface Window {
+  console: Console;
+}
+
+// Globals in the runtime environment
+declare let console: Console;
+declare const window: Window;

--- a/js/runtime.ts
+++ b/js/runtime.ts
@@ -214,9 +214,9 @@ class Compiler {
     module: ts.ModuleKind.AMD,
     outDir: "$deno$",
     inlineSourceMap: true,
-    lib: ["es2017"],
+    lib: ["esnext"],
     inlineSources: true,
-    target: ts.ScriptTarget.ES2017
+    target: ts.ScriptTarget.ESNext
   };
   /*
   allowJs: true,

--- a/js/runtime.ts
+++ b/js/runtime.ts
@@ -131,8 +131,8 @@ export function makeDefine(fileName: string): AmdDefine {
         return localExports;
       } else if (dep === "typescript") {
         return ts;
-      // } else if (dep === "deno") {
-      //   return deno;
+      } else if (dep === "deno") {
+        return deno;
       } else {
         const resolved = resolveModuleName(dep, fileName);
         const depModule = FileModule.load(resolved);

--- a/js/runtime.ts
+++ b/js/runtime.ts
@@ -131,8 +131,8 @@ export function makeDefine(fileName: string): AmdDefine {
         return localExports;
       } else if (dep === "typescript") {
         return ts;
-      } else if (dep === "deno") {
-        return deno;
+      // } else if (dep === "deno") {
+      //   return deno;
       } else {
         const resolved = resolveModuleName(dep, fileName);
         const depModule = FileModule.load(resolved);
@@ -214,7 +214,6 @@ class Compiler {
     module: ts.ModuleKind.AMD,
     outDir: "$deno$",
     inlineSourceMap: true,
-    lib: ["esnext"],
     inlineSources: true,
     target: ts.ScriptTarget.ESNext
   };
@@ -317,7 +316,7 @@ class TypeScriptHost implements ts.LanguageServiceHost {
   }
 
   getDefaultLibFileName(options: ts.CompilerOptions): string {
-    const fn = "lib.d.ts"; // ts.getDefaultLibFileName(options);
+    const fn = "lib.deno.d.ts"; // ts.getDefaultLibFileName(options);
     util.log("getDefaultLibFileName", fn);
     const m = resolveModule(fn, "/$asset$/");
     return m.fileName;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.3.1",
     "tslint-no-circular-imports": "^0.5.0",
-    "typescript": "3.0.0-rc"
+    "typescript": "3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@types/flatbuffers": "^1.9.0",
     "@types/source-map-support": "^0.4.1",
     "flatbuffers": "^1.9.0",
-    "prettier": "^1.13.7",
+    "prettier": "^1.14.0",
     "rollup": "^0.63.2",
     "rollup-pluginutils": "^2.3.0",
     "rollup-plugin-alias": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.3.1",
     "tslint-no-circular-imports": "^0.5.0",
-    "typescript": "2.8.3"
+    "typescript": "3.0.0-rc"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,8 +4,9 @@ import { plugin as analyze } from "rollup-plugin-analyzer";
 import commonjs from "rollup-plugin-commonjs";
 import globals from "rollup-plugin-node-globals";
 import nodeResolve from "rollup-plugin-node-resolve";
-import typescript from "rollup-plugin-typescript2";
+import typescriptPlugin from "rollup-plugin-typescript2";
 import { createFilter } from "rollup-pluginutils";
+import typescript from "typescript";
 
 const mockPath = path.join(__dirname, "js", "mock_builtin");
 const tsconfig = path.join(__dirname, "tsconfig.json");
@@ -122,12 +123,16 @@ export default function makeConfig(commandOptions) {
         }
       }),
 
-      typescript({
+      typescriptPlugin({
         // The build script is invoked from `out/:target` so passing an absolute file path is needed
         tsconfig,
 
         // This provides any overrides to the `tsconfig.json` that are needed to bundle
         tsconfigOverride,
+
+        // This provides the locally configured version of TypeScript instead of the plugins
+        // default version
+        typescript,
 
         // By default, the include path only includes the cwd and below, need to include the root of the project
         // and build path to be passed to this plugin.  This is different front tsconfig.json include

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "removeComments": true,
     "preserveConstEnums": true,
-    "target": "es2017",
+    "target": "esnext",
     "moduleResolution": "node",
     "noImplicitReturns": true,
     "pretty": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -650,9 +650,9 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.8.1"
 
-typescript@3.0.0-rc:
-  version "3.0.0-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.0-rc.tgz#13553808426d393d3f92c054f4fa6f24589549c1"
+typescript@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,9 +448,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.13.7:
-  version "1.13.7"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
+prettier@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.0.tgz#847c235522035fd988100f1f43cf20a7d24f9372"
 
 process-es6@^0.11.6:
   version "0.11.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -650,9 +650,9 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.8.1"
 
-typescript@2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@3.0.0-rc:
+  version "3.0.0-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.0-rc.tgz#13553808426d393d3f92c054f4fa6f24589549c1"
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
This PR updates deno to TypeScript 3.0.1 and creates a specific runtime library for deno named `lib.deno.d.ts` to avoid TypeScript having incorrect types for the runtime environment.

Resolves #417 
Requires ry/deno_third_party#3